### PR TITLE
Add suggestion ranking heuristics

### DIFF
--- a/src/LanguageServer/IdePurescript/Completion.purs
+++ b/src/LanguageServer/IdePurescript/Completion.purs
@@ -112,13 +112,13 @@ rankQualifiedWithType = Ranking \opts ->
 
 rankQualifiedWithSegment :: Ranking { state :: State, qualifier :: String, mod :: String }
 rankQualifiedWithSegment = Ranking \opts ->
-    split (Pattern ".") opts.mod
-        # foldMapWithIndex (\ix segment -> unwrap rankSegmentPrefix { ix, segment, prefix: opts.qualifier })
+    let segments = split (Pattern ".") opts.mod
+    in segments # foldMapWithIndex (\ix segment -> unwrap rankSegmentPrefix { len: Arr.length segments, ix, segment, prefix: opts.qualifier })
 
-rankSegmentPrefix :: Ranking { ix :: Int, segment :: String, prefix :: String }
-rankSegmentPrefix = Ranking \{ ix, segment, prefix } ->
+rankSegmentPrefix :: Ranking { len :: Int, ix :: Int, segment :: String, prefix :: String }
+rankSegmentPrefix = Ranking \{ len, ix, segment, prefix } ->
     case indexOf (Pattern prefix) segment of
-        Just 0 -> SuggestionRank.fromInt ((1 + ix) * (1 + (length segment - length prefix)))
+        Just 0 -> SuggestionRank.fromInt $ (1 + ix) * (1 + (length segment - length prefix)) + (len - ix)
         _ -> bottom
 
 rankQualifiedWithAbv :: Ranking { state :: State, qualifier :: String, mod :: String }

--- a/src/LanguageServer/IdePurescript/SuggestionRank.purs
+++ b/src/LanguageServer/IdePurescript/SuggestionRank.purs
@@ -2,13 +2,17 @@ module LanguageServer.IdePurescript.SuggestionRank
   ( SuggestionRank
   , fromInt
   , toString
+  , Ranking(..)
   ) where
 
 import Prelude
 
 import Data.Char as Char
 import Data.Enum (class Enum)
+import Data.Functor.Contravariant (class Contravariant)
 import Data.Maybe (Maybe(..))
+import Data.Monoid (class Monoid)
+import Data.Newtype (class Newtype)
 import Data.Ordering (invert)
 import Data.String as String
 
@@ -31,8 +35,28 @@ instance enumSuggestionRank :: Enum SuggestionRank where
     | n == 100  = Nothing
     | otherwise = Just (SuggestionRank (n + 1))
 
+instance semigroupSuggestionRank :: Semigroup SuggestionRank where
+  append (SuggestionRank a) (SuggestionRank b) = SuggestionRank (min a b)
+
+instance monoidSuggestionRank :: Monoid SuggestionRank where
+  mempty = bottom
+
 fromInt :: Int -> SuggestionRank
 fromInt = SuggestionRank <<< clamp 0 100
 
 toString :: SuggestionRank -> String
 toString (SuggestionRank n) = String.singleton (Char.fromCharCode (65 + n))
+
+newtype Ranking a = Ranking (a -> SuggestionRank)
+
+derive instance newtypeRanking :: Newtype (Ranking a) _
+
+instance semigroupRanking :: Semigroup (Ranking a) where
+  append (Ranking f) (Ranking g) = Ranking \a ->
+    let rank = f a in if rank == top then rank else rank <> g a
+
+instance monoidRanking :: Monoid (Ranking a) where
+  mempty = Ranking (const bottom)
+
+instance contravariantRanking :: Contravariant Ranking where
+  cmap f (Ranking g) = Ranking (f >>> g)

--- a/src/LanguageServer/IdePurescript/SuggestionRank.purs
+++ b/src/LanguageServer/IdePurescript/SuggestionRank.purs
@@ -1,0 +1,38 @@
+module LanguageServer.IdePurescript.SuggestionRank
+  ( SuggestionRank
+  , fromInt
+  , toString
+  ) where
+
+import Prelude
+
+import Data.Char as Char
+import Data.Enum (class Enum)
+import Data.Maybe (Maybe(..))
+import Data.Ordering (invert)
+import Data.String as String
+
+newtype SuggestionRank = SuggestionRank Int
+
+derive instance eqSuggestionRank :: Eq SuggestionRank
+
+instance ordSuggestionRank :: Ord SuggestionRank where
+  compare (SuggestionRank a) (SuggestionRank b) = invert (compare a b)
+
+instance boundedSuggestionRank :: Bounded SuggestionRank where
+  top = SuggestionRank 0
+  bottom = SuggestionRank 100
+
+instance enumSuggestionRank :: Enum SuggestionRank where
+  succ (SuggestionRank n)
+    | n == 0    = Nothing
+    | otherwise = Just (SuggestionRank (n - 1))
+  pred (SuggestionRank n)
+    | n == 100  = Nothing
+    | otherwise = Just (SuggestionRank (n + 1))
+
+fromInt :: Int -> SuggestionRank
+fromInt = SuggestionRank <<< clamp 0 100
+
+toString :: SuggestionRank -> String
+toString (SuggestionRank n) = String.singleton (Char.fromCharCode (65 + n))

--- a/src/LanguageServer/IdePurescript/SuggestionRank.purs
+++ b/src/LanguageServer/IdePurescript/SuggestionRank.purs
@@ -3,6 +3,7 @@ module LanguageServer.IdePurescript.SuggestionRank
   , fromInt
   , toString
   , Ranking(..)
+  , cmapRanking
   ) where
 
 import Prelude
@@ -10,9 +11,9 @@ import Prelude
 import Data.Char as Char
 import Data.Enum (class Enum)
 import Data.Functor.Contravariant (class Contravariant)
-import Data.Maybe (Maybe(..))
-import Data.Monoid (class Monoid)
-import Data.Newtype (class Newtype)
+import Data.Maybe (Maybe(..), maybe)
+import Data.Monoid (class Monoid, mempty)
+import Data.Newtype (class Newtype, unwrap)
 import Data.Ordering (invert)
 import Data.String as String
 
@@ -25,14 +26,14 @@ instance ordSuggestionRank :: Ord SuggestionRank where
 
 instance boundedSuggestionRank :: Bounded SuggestionRank where
   top = SuggestionRank 0
-  bottom = SuggestionRank 100
+  bottom = SuggestionRank 25
 
 instance enumSuggestionRank :: Enum SuggestionRank where
   succ (SuggestionRank n)
     | n == 0    = Nothing
     | otherwise = Just (SuggestionRank (n - 1))
   pred (SuggestionRank n)
-    | n == 100  = Nothing
+    | n == 25  = Nothing
     | otherwise = Just (SuggestionRank (n + 1))
 
 instance semigroupSuggestionRank :: Semigroup SuggestionRank where
@@ -42,7 +43,7 @@ instance monoidSuggestionRank :: Monoid SuggestionRank where
   mempty = bottom
 
 fromInt :: Int -> SuggestionRank
-fromInt = SuggestionRank <<< clamp 0 100
+fromInt = SuggestionRank <<< clamp 0 25
 
 toString :: SuggestionRank -> String
 toString (SuggestionRank n) = String.singleton (Char.fromCharCode (65 + n))
@@ -60,3 +61,6 @@ instance monoidRanking :: Monoid (Ranking a) where
 
 instance contravariantRanking :: Contravariant Ranking where
   cmap f (Ranking g) = Ranking (f >>> g)
+
+cmapRanking :: forall a b. (b -> Maybe a) -> Ranking a -> Ranking b
+cmapRanking k r = Ranking (maybe mempty (unwrap r) <<< k)


### PR DESCRIPTION
Depends on https://github.com/nwolverson/purescript-ide-purescript-core/pull/13

The ranking format is kind of weird. VSCode uses `rankText` to affect ordering (actual ordering of the results has no effect), so I'm just returning  "a" or "z", where "a" forces a higher ranking.

<img width="759" alt="screen shot 2018-02-17 at 10 09 30 pm" src="https://user-images.githubusercontent.com/144058/36348936-c20728b8-142f-11e8-9fa7-3776e7ca8da7.png">
<img width="780" alt="screen shot 2018-02-17 at 10 09 49 pm" src="https://user-images.githubusercontent.com/144058/36348937-c228d2c4-142f-11e8-9852-14ac80c3e5e6.png">
