### PR TITLE
Add documentation to hover

### DIFF
--- a/src/LanguageServer/Types.purs
+++ b/src/LanguageServer/Types.purs
@@ -198,7 +198,7 @@ symbolKindToInt = case _ of
   BooleanSymbolKind -> 17
   ArraySymbolKind -> 18
  
-newtype Hover = Hover { contents :: MarkedString, range :: Nullable Range }
+newtype Hover = Hover { contents :: MarkupContent, range :: Nullable Range }
 
 newtype Command = Command { title :: String, command :: String, arguments :: Nullable (Array Foreign) }
 


### PR DESCRIPTION
Old version:
![screenshot from 2018-02-26 01-05-11](https://user-images.githubusercontent.com/5427083/36648262-5a23c8ce-1a91-11e8-8155-3f42447af736.png)
![screenshot from 2018-02-26 01-05-13](https://user-images.githubusercontent.com/5427083/36648263-5b723db4-1a91-11e8-91cf-43a3e4e3bf71.png)
![screenshot from 2018-02-26 01-05-16](https://user-images.githubusercontent.com/5427083/36648266-5dbe4cfc-1a91-11e8-89c2-d96b9c1dce6b.png)

New version (including clickable link if docs contains URL):
![screenshot from 2018-02-26 01-04-35](https://user-images.githubusercontent.com/5427083/36648272-7260d210-1a91-11e8-8ecd-6b56080f9e72.png)
![screenshot from 2018-02-26 01-04-30](https://user-images.githubusercontent.com/5427083/36648284-8ecc69d2-1a91-11e8-9d87-830b1b92b561.png)

![screenshot from 2018-02-26 01-04-52](https://user-images.githubusercontent.com/5427083/36648276-75461fbc-1a91-11e8-9979-edde6ce10033.png)

