### PR TITLE
Make go-to-definition work with atom-ide-purescript non-Bower projects.

### DIFF
--- a/src/LanguageServer/IdePurescript/Server.purs
+++ b/src/LanguageServer/IdePurescript/Server.purs
@@ -50,8 +50,8 @@ startServer' settings root cb logCb = do
     , port: Config.pscIdePort settings
     } (fromMaybe "" root) (Config.addNpmPath settings) cb logCb
   where
-    globs = getGlob Config.srcPath <> getGlob Config.packagePath
-    getGlob fn = fn settings # case _ of 
+    globs = getGlob Config.srcPath <> getGlob Config.packagePath <> Config.sourceGlobs settings
+    getGlob fn = fn settings # case _ of
       glob | not (null glob) -> [ glob <> "/**/*.purs" ]
       _ -> []
     exe = if Config.usePurs settings then Config.pursExe settings else Config.serverExe settings


### PR DESCRIPTION
The sourceGlobs config (used by Atom) is no longer being ignored. This
fixes issue #47.

This change keeps using `packagePath` (the path to the `bower_components` folder - i.e. not including the trailing `/**/*.purs`, which is automatically added) which is set by VSCode, but also uses `sourceGlobs` (an array of globs that are passed through to the compiler without modification).