### PR TITLE
Add new config option for calling `spago sources` to get sources globs.

### DIFF
--- a/src/LanguageServer/IdePurescript/Config.purs
+++ b/src/LanguageServer/IdePurescript/Config.purs
@@ -106,6 +106,9 @@ polling = getBoolean "polling" false
 addPscPackageSources :: ConfigFn Boolean
 addPscPackageSources = getBoolean "addPscPackageSources" false
 
+addSpagoSources :: ConfigFn Boolean
+addSpagoSources = getBoolean "addSpagoSources" false
+
 logLevel :: ConfigFn (Maybe LogLevel)
 logLevel = getString "pscIdelogLevel" "" >>> case _ of
     "all" -> Just All


### PR DESCRIPTION
For issue #43

If this is accepted, I can also put support into the atom and vscode plugins.