### PR TITLE
check if PURS_IDE_SOURCES env var is being used in startup

### DIFF
--- a/src/LanguageServer/IdePurescript/Main.purs
+++ b/src/LanguageServer/IdePurescript/Main.purs
@@ -8,7 +8,7 @@ import Data.Array (length, (!!), (\\))
 import Data.Array as Array
 import Data.Either (Either(..), either)
 import Data.Foldable (for_, or)
-import Data.Maybe (Maybe(..), fromMaybe, maybe)
+import Data.Maybe (Maybe(..), fromMaybe, isNothing, maybe)
 import Data.Newtype (over, un, unwrap)
 import Data.Nullable (toMaybe, toNullable)
 import Data.Profunctor.Strong (first)
@@ -38,7 +38,7 @@ import LanguageServer.IdePurescript.FoldingRanges (getFoldingRanges)
 import LanguageServer.IdePurescript.Imports (addCompletionImport, addModuleImport', getAllModules)
 import LanguageServer.IdePurescript.References (getReferences)
 import LanguageServer.IdePurescript.Search (search)
-import LanguageServer.IdePurescript.Server (loadAll, retry, startServer')
+import LanguageServer.IdePurescript.Server (getEnvPursIdeSources, loadAll, retry, startServer')
 import LanguageServer.IdePurescript.Symbols (getDefinition, getDocumentSymbols, getWorkspaceSymbols)
 import LanguageServer.IdePurescript.Tooltips (getTooltips)
 import LanguageServer.IdePurescript.Types (ServerState(..), CommandHandler)
@@ -303,7 +303,8 @@ main = do
           startPscIdeServer
           let outputDir = Config.effectiveOutputDirectory c
           hasPackageFile <- or <$> traverse FS.exists ["bower.json", "psc-package.json", "spago.dhall"]
-          when (not hasPackageFile) do
+          envIdeSources <- getEnvPursIdeSources
+          when (not hasPackageFile && isNothing envIdeSources) do
             liftEffect $ showError conn "It doesn't look like the workspace root is a PureScript project (has bower.json/psc-package.json/spago.dhall). The PureScript project should be opened as a root workspace folder."
           exists <- FS.exists outputDir
           when (not exists) $ liftEffect $ launchAffLog do

--- a/src/LanguageServer/IdePurescript/Server.purs
+++ b/src/LanguageServer/IdePurescript/Server.purs
@@ -4,7 +4,7 @@ import Prelude
 
 import Data.Array (filter, head)
 import Data.Either (Either(..), either)
-import Data.Maybe (Maybe(..), fromMaybe)
+import Data.Maybe (Maybe(..))
 import Data.String (null)
 import Data.String.Regex as Regex
 import Data.String.Regex.Flags (noFlags)
@@ -12,7 +12,7 @@ import Data.String.Regex.Unsafe (unsafeRegex)
 import Data.String.Utils (lines)
 import Data.Time.Duration (Milliseconds(..))
 import Effect.Aff (Aff, attempt, delay, makeAff)
-import Effect.Class (liftEffect)
+import Effect.Class (class MonadEffect, liftEffect)
 import Foreign (Foreign)
 import IdePurescript.Exec (findBins, getPathVar)
 import IdePurescript.PscIdeServer (ErrorLevel(..), Notify)
@@ -41,9 +41,12 @@ retry logError n a | n > 0 = do
             retry logError (n - 1) a
 retry _ _ a = a
 
+getEnvPursIdeSources :: forall m. MonadEffect m => m (Maybe String)
+getEnvPursIdeSources = liftEffect $ lookupEnv "PURS_IDE_SOURCES"
+
 startServer' :: Settings -> String -> Notify -> Notify -> Aff { port :: Maybe Int, quit :: Aff Unit }
 startServer' settings root cb logCb = do
-  envIdeSources :: Maybe String <- liftEffect $ lookupEnv "PURS_IDE_SOURCES"
+  envIdeSources <- getEnvPursIdeSources
   packageGlobs <- case envIdeSources of
     Just sourcesString -> do
       liftEffect $ logCb Info "Using sources from PURS_IDE_SOURCES"


### PR DESCRIPTION
I realized this probably needs to be done. I also realized that it seems like WSL2 might not pass env vars correctly, but I have to dig into this more.