### PR TITLE
fix concurrency issue in go to definition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -478,6 +478,11 @@
       "integrity": "sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==",
       "dev": true
     },
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+    },
     "validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "server.js"
   ],
   "dependencies": {
+    "uuid": "^3.3.2",
     "vscode-languageserver": "^6.1.1",
     "vscode-languageserver-textdocument": "^1.0.1",
     "vscode-uri": "^2.1.1",

--- a/spago.dhall
+++ b/spago.dhall
@@ -17,6 +17,7 @@ You can edit this file as you like.
     , "psci-support"
     , "stringutils"
     , "test-unit"
+    , "uuid"
     ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]

--- a/src/IdePurescript/Modules.purs
+++ b/src/IdePurescript/Modules.purs
@@ -29,6 +29,7 @@ import Data.String (Pattern(Pattern), split)
 import Data.String.Regex (regex) as R
 import Data.String.Regex.Flags (global, noFlags, multiline) as R
 import Data.Tuple (Tuple(..))
+import Data.UUID (genUUID)
 import Effect (Effect)
 import Effect.Aff (Aff, attempt)
 import Effect.Class (liftEffect)
@@ -148,8 +149,9 @@ data ImportResult = UpdatedImports String | AmbiguousImport (Array C.TypeInfo) |
 makeTempFile :: Path -> String -> Aff Path
 makeTempFile fileName text = do
   dir <- liftEffect tmpDir
+  uuid <- liftEffect genUUID
   let name = replace' (R.regex "[\\/\\\\:]" R.global) "-" fileName
-      tmpFile = dir <> sep <> "ide-purescript-" <> name
+      tmpFile = dir <> sep <> "ide-purescript-" <> show uuid <> "-" <> name
   FS.writeTextFile UTF8 tmpFile text
   pure tmpFile
 


### PR DESCRIPTION
If you go back and forth between files quickly using go to definition and go back, then extension features like go to definition, hover, etc. stop working. It gets fixed once you close the file and load it back again.

The following changes fixes the problem. 