### PR TITLE
Find references will work immediately

### DIFF
--- a/src/LanguageServer/IdePurescript/Main.purs
+++ b/src/LanguageServer/IdePurescript/Main.purs
@@ -208,7 +208,7 @@ main' { filename: logFile, config: cmdLineConfig } = do
 
     onFoldingRanges conn $ runHandler "onFoldingRanges" getTextDocUri (getFoldingRanges documents)
     onDocumentFormatting conn $ runHandler "onDocumentFormatting" getTextDocUri (getFormattedDocument logError documents)
-    onReferences conn $ runHandler "onReferences" (const Nothing) (getReferences documents)
+    onReferences conn $ runHandler "onReferences" getTextDocUri (getReferences documents)
     onHover conn $ runHandler "onHover" getTextDocUri (getTooltips documents)
     onCodeAction conn $ runHandler "onCodeAction" getTextDocUri (getActions documents)
     onShutdown conn $ fromAff stopPscIdeServer


### PR DESCRIPTION
If `getTextDocUri` will not be passed to `runHandler`, then `updateModules` will not be triggered, and `modules` and `moduleFile` not be updated. Passing it also for this handler will make `show usages/references` work, when opening a file.

## Demo

1. Open https://github.com/jonasbuntinx/purescript-react-realworld/blob/d59eaf5c3431ea465db792f291eede42dc6190c7/src/Conduit/Page/Article.purs#L52
2. Wait 10 seconds
3. Trigger "Show usages" for `mkArticlePage`

Before this PR, it won't work. With this PR it'll jump to where it is used.

## Issue

Closes #88

