### PR TITLE
Codeaction: Fix intersection of two ranges

### DIFF
--- a/src/LanguageServer/IdePurescript/CodeActions.purs
+++ b/src/LanguageServer/IdePurescript/CodeActions.purs
@@ -84,7 +84,7 @@ getActions documents settings state@(ServerState { diagnostics, conn: Just conn 
         _ -> pure []
     commandForCode _ = pure []
 
-    intersects (Range { start, end }) (Range { start: start', end: end' }) = start <= end' && start' >= end
+    intersects (Range { start, end }) (Range { start: start', end: end' }) = start <= end' && start' <= end
 
 getActions _ _ _ _ = pure []
 


### PR DESCRIPTION
This is one of the cases where I double check a hundred times, just to make sure I'm not mistaken :D 

I'm pretty sure though, that the current/previous implementation of `intersects` itself is wrong.

To have `start <= end' && start' >= end` (current implementation) be true, it would look like this. But the ranges wouldn't intersect.

```
[start]--------[end]
                           [start']----------[end']
````

I think it should be: `start <= end' && start' <= end`