### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,16 @@ Configuration with [coc.nvim](https://github.com/neoclide/coc.nvim/wiki/Language
       "filetypes": ["purescript"],
       "trace.server": "off",
       "rootPatterns": ["bower.json", "psc-package.json", "spago.dhall"],
+      "initializationOptions" : { 
+        "addNpmPath"     : true,
+        "addSpagoSources": true,
+        "buildCommand"   : "spago build --purs-args --json-errors",
+        "autocompleteAllModules": true,
+        "autocompleteAddImport": true,
+        "fastRebuild": true
+      },
       "settings": {
         "purescript": {
-          "addSpagoSources": true // etc
         }
       }
     }


### PR DESCRIPTION
Use initialization options instead of `settings` in json for `coc`

It took me way longer than i'm willing to admit to finding this setting. I was able to get builds on save by using this and not need a watcher when running parcel. It did not work when in the `settings.purescript` keys, so I think this may be a nice to add to people don't have to go digging.