### PR TITLE
Add flake.nix to list of files for detecting projects

### DIFF
--- a/src/LanguageServer/IdePurescript/Main.purs
+++ b/src/LanguageServer/IdePurescript/Main.purs
@@ -316,14 +316,14 @@ autoStartPcsIdeServer config conn state logError documents  = do
         $ resolvePath $ Config.effectiveOutputDirectory c
 
       hasPackageFile <- or <$> traverse (FS.exists <=< liftEffect  <<< resolvePath)
-        ["bower.json", "psc-package.json", "spago.dhall"]
+        ["bower.json", "psc-package.json", "spago.dhall", "flake.nix"]
 
       envIdeSources <- Server.getEnvPursIdeSources
 
       when (not hasPackageFile && isNothing envIdeSources) do
         liftEffect $ showError conn
           ( "It doesn't look like the workspace root is a PureScript project"
-            <> "(has bower.json/psc-package.json/spago.dhall)."
+            <> "(has bower.json/psc-package.json/spago.dhall/flake.nix)."
             <> "The PureScript project should be opened as a root workspace folder."
           )
 


### PR DESCRIPTION
I've been working on [purs-nix](https://github.com/ursi/purs-nix) which is a tool that lets you manage your purescript projects with just nix. Because of this, there is no `bower.json`, `psc-package.json`, or `spago.dhall` in my directories and the language server is complaining. This fixes the issue by adding `flake.nix` to the list of files it looks for.