### PR TITLE
Add shell.nix to the list of files for detecting projects

### DIFF
--- a/src/LanguageServer/IdePurescript/Main.purs
+++ b/src/LanguageServer/IdePurescript/Main.purs
@@ -301,14 +301,14 @@ autoStartPcsIdeServer config conn state logError documents  = do
         $ resolvePath $ Config.effectiveOutputDirectory c
 
       hasPackageFile <- or <$> traverse (FS.exists <=< liftEffect  <<< resolvePath)
-        ["bower.json", "psc-package.json", "spago.dhall", "flake.nix"]
+        ["bower.json", "psc-package.json", "spago.dhall", "flake.nix", "shell.nix"]
 
       envIdeSources <- Server.getEnvPursIdeSources
 
       when (not hasPackageFile && isNothing envIdeSources) do
         liftEffect $ showError conn
           ( "It doesn't look like the workspace root is a PureScript project"
-            <> "(has bower.json/psc-package.json/spago.dhall/flake.nix)."
+            <> "(has bower.json/psc-package.json/spago.dhall/flake.nix/shell.nix)."
             <> "The PureScript project should be opened as a root workspace folder."
           )
 


### PR DESCRIPTION
**purs-nix** is now compatible with Nix stable, which uses a `shell.nix` file instead of `flake.nix`