### PR TITLE
make tsc generate LF newlines

### DIFF
--- a/src/LanguageServer/tsconfig.json
+++ b/src/LanguageServer/tsconfig.json
@@ -1,8 +1,9 @@
 {
-	"compilerOptions": {
-		"module": "commonjs",
-		"target": "ES5",
-		"sourceMap": false,
-        "noImplicitAny": true
-	}
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES5",
+    "sourceMap": false,
+    "noImplicitAny": true,
+    "newLine": "LF"
+  }
 }


### PR DESCRIPTION
This is just to make `tsc` always generate LF line endings (actual on windows) so it doesn't differ from existing in the git. Also, it updates file formatting to standard 2-spaces indent.