### PR TITLE
Skip lib sources when rebuilding opened files

### DIFF
--- a/src/LanguageServer/tsconfig.json
+++ b/src/LanguageServer/tsconfig.json
@@ -1,8 +1,9 @@
 {
-	"compilerOptions": {
-		"module": "commonjs",
-		"target": "ES5",
-		"sourceMap": false,
-        "noImplicitAny": true
-	}
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES5",
+    "sourceMap": false,
+    "noImplicitAny": true,
+    "newLine": "LF"
+  }
 }


### PR DESCRIPTION
Files that are opened in the editor automatically rebuilt (to show diagnostics without the need to update and save it), but it is not so actual for the library sources, esp considering that compiler [currently rebuilds if they are not changed ](https://github.com/purescript/purescript/issues/4066)(and rebuild is actually not needed to be rebuilt, that may unnecessarily trigger file watching tools). So this checks if the file path contains `.spago` or `bower_components` to skip it.