### PR TITLE
Fix windows env path

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "purescript.addNpmPath": true
+}

--- a/spago.dhall
+++ b/spago.dhall
@@ -16,6 +16,7 @@ You can edit this file as you like.
   , "contravariant"
   , "control"
   , "datetime"
+  , "debug"
   , "effect"
   , "either"
   , "enums"


### PR DESCRIPTION
This should fix https://github.com/nwolverson/purescript-language-server/issues/133.

Also it adds `addNpmPath` setting for the project itself, as it seems actual, and adds `debug` package that is useful for debugging.