### PR TITLE
Adds buildOnSave command to allow full rebuild on save

### DIFF
--- a/src/LanguageServer/IdePurescript/Config.purs
+++ b/src/LanguageServer/IdePurescript/Config.purs
@@ -100,6 +100,9 @@ addPscPackageSources = getBoolean "addPscPackageSources" false
 addSpagoSources :: ConfigFn Boolean
 addSpagoSources = getBoolean "addSpagoSources" false
 
+buildOnSave :: ConfigFn Boolean
+buildOnSave = getBoolean "buildOnSave" false
+
 logLevel :: ConfigFn (Maybe LogLevel)
 logLevel = getString "pscIdelogLevel" "" >>> case _ of
     "all" -> Just All

--- a/src/LanguageServer/IdePurescript/Main.purs
+++ b/src/LanguageServer/IdePurescript/Main.purs
@@ -483,9 +483,14 @@ handleEvents config conn state documents logError = do
                 { buildQueue = Object.insert uri document (st.buildQueue)
                 })) state
 
-  onDidSaveDocument documents \{ document } -> launchAffLog do
-    rebuildAndSendDiagnostics config conn state logError document
-
+  onDidSaveDocument documents \{ document } -> do
+    c <- liftEffect $ Ref.read config
+    launchAffLog
+      if Config.buildOnSave c then do
+        s <- liftEffect $ Ref.read state
+        buildProject conn state logError documents c s []
+      else
+        rebuildAndSendDiagnostics config conn state logError document
 
 handleConfig ::
   Ref Foreign ->


### PR DESCRIPTION
This is useful when doing live coding (using VSCode as a repl) and an entire project needs to be coherent in order to successfully reload in the browser.