### PR TITLE
Node 14+ is required engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "main": "./server.js",
   "bin": "./cli.js",
   "engines": {
-    "node": "12"
+    "node": ">=14"
   },
   "targets": {
     "main": {


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining

Optional chaining is not supported by Node 12. 14 is current LTS so no big issue.