### PR TITLE
Config: Empty formatter, no formatter

### DIFF
--- a/src/LanguageServer/IdePurescript/Config.purs
+++ b/src/LanguageServer/IdePurescript/Config.purs
@@ -198,12 +198,10 @@ formatter :: ConfigFn Formatter
 formatter =
   getString "formatter" ""
     >>> case _ of
-        "none" -> NoFormatter
-        "" -> NoFormatter
         "purty" -> Purty
         "purs-tidy" -> PursTidy
         "pose" -> Pose
-        _ -> Purty
+        "" -> NoFormatter
 
 codegenTargets :: ConfigFn (Maybe (Array CodegenTarget))
 codegenTargets =

--- a/src/LanguageServer/IdePurescript/Config.purs
+++ b/src/LanguageServer/IdePurescript/Config.purs
@@ -200,6 +200,7 @@ formatter =
     >>> case _ of
         "purty" -> Purty
         "purs-tidy" -> PursTidy
+        "tidy" -> PursTidy
         "pose" -> Pose
         "" -> NoFormatter
 

--- a/src/LanguageServer/IdePurescript/Config.purs
+++ b/src/LanguageServer/IdePurescript/Config.purs
@@ -199,6 +199,7 @@ formatter =
   getString "formatter" ""
     >>> case _ of
         "none" -> NoFormatter
+        "" -> NoFormatter
         "purty" -> Purty
         "purs-tidy" -> PursTidy
         "pose" -> Pose


### PR DESCRIPTION
Hey,

Before looking it up, my first try to disable an existing formatter was to set the field to `""`. Later I found out there is `"none"`.

I would also interpret `""` as `NoFormatter`, but it's up to you if you think that's a good idea or not :)