### PR TITLE
Add basic support for JavaScript files

### DIFF
--- a/src/LanguageServer/IdePurescript/FileTypes.purs
+++ b/src/LanguageServer/IdePurescript/FileTypes.purs
@@ -1,0 +1,50 @@
+module LanguageServer.IdePurescript.FileTypes where
+
+import Prelude
+
+import Control.Alternative ((<|>))
+import Data.Map as Map
+import Data.Maybe (Maybe(..))
+import Data.String as String
+
+import LanguageServer.IdePurescript.Types (ServerState(..), ServerStateRec)
+import LanguageServer.Protocol.TextDocument (TextDocument, getText, getUri, getVersion)
+import LanguageServer.Protocol.Types (DocumentStore, DocumentUri(..))
+
+-- | Type representing files passsed by the IDE
+data RelevantFileType
+  = PureScriptFile
+  | JavaScriptFile
+  | UnsupportedFile
+
+derive instance Eq RelevantFileType
+instance Show RelevantFileType where
+  show PureScriptFile = "PureScriptFile"
+  show JavaScriptFile = "JavaScriptFile"
+  show UnsupportedFile = "UnsupportedFile"
+
+uriToRelevantFileType uri = f
+  where
+    extIs = uriExtensionIs uri
+    f
+      | extIs "purs" = PureScriptFile
+      | extIs "js" = JavaScriptFile
+      | otherwise = UnsupportedFile
+
+uriExtensionIs (DocumentUri uri) ext = ext' == after
+  where
+    ext' = "." <> ext
+    {after} = String.splitAt (String.length uri - String.length ext') uri
+
+jsUriToMayPsUri (DocumentUri str) =
+  (String.stripSuffix (String.Pattern ".js") str)
+  <#> (_ <> ".purs")
+  <#> DocumentUri
+
+
+tryGetDocument :: ServerState -> DocumentUri -> Maybe TextDocument
+tryGetDocument (ServerState ssr) uri =
+    -- TODO: find out from maintainers if this fallback ordering is correct
+    (Map.lookup uri ssr.fastRebuildQueue)
+    <|> (Map.lookup uri ssr.diagnosticsQueue)
+    <|> (_.document <$> Map.lookup uri ssr.parsedModules)

--- a/src/LanguageServer/IdePurescript/Types.purs
+++ b/src/LanguageServer/IdePurescript/Types.purs
@@ -11,12 +11,13 @@ import Prelude
 import Data.Map (Map)
 import Data.Maybe (Maybe)
 import Data.Newtype (class Newtype)
+import Data.String as String
 import Effect.Aff (Aff, Fiber)
 import Effect.Timer (TimeoutId)
 import Foreign (Foreign)
 import IdePurescript.Modules (State) as Modules
 import LanguageServer.Protocol.TextDocument (TextDocument)
-import LanguageServer.Protocol.Types (ClientCapabilities, Connection, Diagnostic, DocumentStore, DocumentUri, Settings)
+import LanguageServer.Protocol.Types (ClientCapabilities, Connection, Diagnostic, DocumentStore, DocumentUri(..), Settings)
 import PscIde.Command (RebuildError)
 import PureScript.CST (RecoveredParserResult)
 import PureScript.CST.Types (Module)

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -8,6 +8,7 @@ import Data.Nullable (null, toMaybe)
 import Data.Nullable as Nullable
 import Effect (Effect)
 import IdePurescript.Tokens (identifierAtPoint)
+import LanguageServer.IdePurescript.FileTypes (RelevantFileType(..), uriToRelevantFileType, jsUriToMayPsUri)
 import LanguageServer.Protocol.Text (makeMinimalWorkspaceEdit)
 import LanguageServer.Protocol.Types (DocumentUri(..), Position(..), Range(..), TextDocumentEdit(..), TextEdit(..), WorkspaceEdit(..), ClientCapabilities)
 import Test.Unit (suite, test)
@@ -89,3 +90,18 @@ main =
         let result = identifierAtPoint str 3
         Assert.equal (result <#> _.word) (Just """/\""")
         Assert.equal (result <#> _.range) (Just { left: 3, right: 5 })
+    suite "file handling" do
+          test "Determine file type" do
+            let f x y = Assert.equal x $ uriToRelevantFileType $ DocumentUri y
+            f PureScriptFile "foo/bar/baz.purs"
+            f PureScriptFile "./foo.purs"
+            f PureScriptFile "foo.purs"
+            f JavaScriptFile "foo.js"
+            f UnsupportedFile "foo.xyz"
+          test "convert js uri to ps uri" do
+            let mmUnwrap (DocumentUri x) = x
+            let f x y = Assert.equal (Just x) $ mmUnwrap <$> jsUriToMayPsUri (DocumentUri y)
+            f "foo/bar/baz.purs" "foo/bar/baz.js"
+            f "./foo.purs" "./foo.js"
+            f "foo.purs" "foo.js"
+    


### PR DESCRIPTION
* Modification of JS file triggers evaluation of associated .purs files (same name and path save the extension) if it exists
* Motivated by a need for better user interface in IDE when authoring FFI