### PR TITLE
Update the textDocumentSync capability to spec v3

### DIFF
--- a/src/LanguageServer/Protocol/Setup.js
+++ b/src/LanguageServer/Protocol/Setup.js
@@ -1,4 +1,4 @@
-import { createConnection, TextDocuments, TextDocumentSyncKind, CodeActionKind } from "vscode-languageserver/node";
+import { createConnection, TextDocuments, CodeActionKind } from "vscode-languageserver/node";
 import { TextDocument } from "vscode-languageserver-textdocument";
 export var initConnection = function (commands) {
     return function (cb) {
@@ -14,7 +14,9 @@ export var initConnection = function (commands) {
                 return {
                     capabilities: {
                         // Tell the client that the server works in FULL text document sync mode
-                        textDocumentSync: TextDocumentSyncKind.Full,
+                        textDocumentSync: {
+                            save: { includeText: false }
+                        },
                         // Tell the client that the server support code complete
                         completionProvider: {
                             resolveProvider: false,

--- a/src/LanguageServer/Protocol/Setup.ts
+++ b/src/LanguageServer/Protocol/Setup.ts
@@ -3,7 +3,6 @@ import {
   createConnection,
   InitializeParams,
   TextDocuments,
-  TextDocumentSyncKind,
   CodeActionKind,
   LSPObject
 } from "vscode-languageserver/node";
@@ -26,7 +25,9 @@ export const initConnection =
       return {
         capabilities: {
           // Tell the client that the server works in FULL text document sync mode
-          textDocumentSync: TextDocumentSyncKind.Full,
+          textDocumentSync: {
+            save: { includeText: false }
+          },
           // Tell the client that the server support code complete
           completionProvider: {
             resolveProvider: false,


### PR DESCRIPTION
Currently the language servers sends `TextDocumentSyncKind` as its `textDocumentSync` capability.

The current LSP spec (https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#serverCapabilities) expects a `TextDocumentSyncOptions` object instead.

`TextDocumentSyncKind` doesn't appear to be deprecated, but it's still accepted only for backwards compatibility.

This prevents some clients (for example the helix editor) from working with the purescript language server.


I have made some tests, and this looks like the minimal working config that vscode, emacs and helix accept happily. I'm a bit confused, as these options should correspond to a `TextDocumentSyncKind.None` and the server is sending `TextDocumentSyncKind.Full` now.


