### PR TITLE
Add `formatter` option in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Run `:CocConfig` and add `"purescript"` in the `"languageserver"` section as fol
         "purescript": {
           "addSpagoSources": true,
           "addNpmPath": true, // Set to true if using a local purty install for formatting
-          "formatter": "purs-tidy" // Default: purty. Set to none to disable.
+          "formatter": "purs-tidy"
           // etc
         }
       }

--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ Run `:CocConfig` and add `"purescript"` in the `"languageserver"` section as fol
       "settings": {
         "purescript": {
           "addSpagoSources": true,
-          "addNpmPath": true // Set to true if using a local purty install for formatting
+          "addNpmPath": true, // Set to true if using a local purty install for formatting
+          "formatter": "purs-tidy" // Default: purty. Set to none to disable.
           // etc
         }
       }


### PR DESCRIPTION
Ref #179 

Add `formatter` option for Coc.nvim in README.md

This is important for Apple Silicon users as purty does not provide a arm64 build for it.