### PR TITLE
Allow lookup of Constructors again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 bower_components/
 node_modules/
 output/
+output-es/
 bundle.js*
 server.js*
 .psc*


### PR DESCRIPTION
The filter for identifiers was too strict.
Because if you're looking for `Just` it won't appear in the list of identifiers for an import as `Just` or `(Just)` but rather `Maybe(..)`.

That kind of means in the current shape, this could lead to false positives when names overlap.
I think this could be improved by either returning an exploded list of identifiers from psc-ide (`Maybe`, `Just`, `Nothing`) instead of (`Maybe`) for these kinds of imports.
Maybe also by being more type-safe about the types of the identifiers (is it a type alias, or a constructor, or a type name or a newtype or whatever) and matching this info with what we get from the CST parser.

Closes #145 