### PR TITLE
Formatting sources with purs-tidy

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+d5aeaaef2a2abac8ab8bd529cc71e6cb81202738 # tidy formatting Feb 28, 2023
+2e584a0baeb2837b856a35245e7a34687fc7d165 # pose formatting Oct 16, 2021

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -3,7 +3,7 @@
   "importWrap": "source",
   "indent": 2,
   "operatorsFile": null,
-  "ribbon": 0.8,
+  "ribbon": 0.9,
   "typeArrowPlacement": "last",
   "unicode": "never",
   "width": 100

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "ide",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 0.8,
+  "typeArrowPlacement": "last",
+  "unicode": "never",
+  "width": 100
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,7 @@
 {
-  "purescript.formatter": "pose"
+  "purescript.formatter": "purs-tidy",
+  "purescript.addNpmPath": true,
+  "[purescript]": {   
+    "editor.defaultFormatter": "nwolverson.ide-purescript"
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.17.1",
       "license": "MIT",
       "dependencies": {
+        "purs-tidy": "^0.9.2",
         "shell-quote": "^1.7.2",
         "uuid": "^3.3.2",
         "vscode-jsonrpc": "^8.0.0-next.2",
@@ -964,6 +965,14 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/purs-tidy": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/purs-tidy/-/purs-tidy-0.9.2.tgz",
+      "integrity": "sha512-v7Do4E9Tx2OqEhJXKl5tJxjRcmDilMObm0+XgYphpbMelkUQ+CfhtetIk294byhaL18OpEHqmO6BUkyNCBJDpQ==",
+      "bin": {
+        "purs-tidy": "bin/index.js"
+      }
+    },
     "node_modules/read-pkg": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
@@ -1906,6 +1915,11 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
       "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
       "dev": true
+    },
+    "purs-tidy": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/purs-tidy/-/purs-tidy-0.9.2.tgz",
+      "integrity": "sha512-v7Do4E9Tx2OqEhJXKl5tJxjRcmDilMObm0+XgYphpbMelkUQ+CfhtetIk294byhaL18OpEHqmO6BUkyNCBJDpQ=="
     },
     "read-pkg": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "build:bundle-deps": "npm run build:bundle -- --outfile=bundle.js ",
     "watch:bundle": "npm run build:bundle-nodeps -- --watch",
     "watch:tsc": "npm run build:tsc -- --watch",
-    "format:js": "prettier --write ./{src,test}/**/*.{ts,js} && npm run build:tsc"
+    "format:js": "prettier --write ./{src,test}/**/*.{ts,js} && npm run build:tsc",
+    "format:purs": "purs-tidy format-in-place src/**/*.purs"
   },
   "files": [
     "server.js"
@@ -46,11 +47,11 @@
     "which": "^2.0.2"
   },
   "devDependencies": {
-    "@rowtype-yoga/prettier-plugin-purescript": "^1.11.2",
     "@types/node": "^16.9.6",
     "esbuild": "^0.13.15",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.4.1",
+    "purs-tidy": "^0.9.2",
     "typescript": "^4.8.0-dev.20220601"
   }
 }

--- a/spago.dhall
+++ b/spago.dhall
@@ -16,6 +16,7 @@ You can edit this file as you like.
   , "contravariant"
   , "control"
   , "datetime"
+  , "debug"
   , "effect"
   , "either"
   , "enums"

--- a/src/IdePurescript/Completion.purs
+++ b/src/IdePurescript/Completion.purs
@@ -24,14 +24,14 @@ import IdePurescript.Tokens (containsArrow, identPart, modulePart, moduleRegex, 
 import PscIde.Command (CompletionOptions(..), DeclarationType(..), Namespace, TypeInfo(..))
 import PscIde.Command as C
 
-type ModuleInfo
-  = { modules :: Array String
-    , getQualifiedModule :: String -> Array String
-    , mainModule :: Maybe String
-    , importedModules :: Array String
-    , openModules :: Array String
-    , candidateModules :: String -> Array String
-    }
+type ModuleInfo =
+  { modules :: Array String
+  , getQualifiedModule :: String -> Array String
+  , mainModule :: Maybe String
+  , importedModules :: Array String
+  , openModules :: Array String
+  , candidateModules :: String -> Array String
+  }
 
 data SuggestionType
   = Module
@@ -59,7 +59,9 @@ parseSuggestionType = case _ of
   _ -> Nothing
 
 explicitImportRegex :: Either String Regex
-explicitImportRegex = regex ("""^import\s+""" <> modulePart <> """\s+\([^)]*?""" <> identPart <> "$") noFlags
+explicitImportRegex = regex
+  ("""^import\s+""" <> modulePart <> """\s+\([^)]*?""" <> identPart <> "$")
+  noFlags
 
 getModuleSuggestions :: Int -> String -> Aff (Array String)
 getModuleSuggestions port prefix = do
@@ -67,8 +69,20 @@ getModuleSuggestions port prefix = do
   pure $ filter (\m -> indexOf (Pattern prefix) m == Just 0) list
 
 data SuggestionResult
-  = ModuleSuggestion { text :: String, suggestType :: SuggestionType, prefix :: String }
-  | IdentSuggestion { origMod :: String, exportMod :: String, exportedFrom :: Array String, identifier :: String, qualifier :: Maybe String, valueType :: String, suggestType :: SuggestionType, namespace :: Maybe C.Namespace, prefix :: String, documentation :: Maybe String }
+  = ModuleSuggestion
+      { text :: String, suggestType :: SuggestionType, prefix :: String }
+  | IdentSuggestion
+      { origMod :: String
+      , exportMod :: String
+      , exportedFrom :: Array String
+      , identifier :: String
+      , qualifier :: Maybe String
+      , valueType :: String
+      , suggestType :: SuggestionType
+      , namespace :: Maybe C.Namespace
+      , prefix :: String
+      , documentation :: Maybe String
+      }
   | QualifierSuggestion { text :: String, mod :: String }
 
 getSuggestions ::
@@ -82,9 +96,18 @@ getSuggestions ::
   , preferredModules :: Array String
   } ->
   Aff { results :: Array SuggestionResult, isIncomplete :: Boolean }
-getSuggestions _notify port
+getSuggestions
+  _notify
+  port
   { line
-  , moduleInfo: { modules, getQualifiedModule, mainModule, importedModules, openModules: _, candidateModules }
+  , moduleInfo:
+      { modules
+      , getQualifiedModule
+      , mainModule
+      , importedModules
+      , openModules: _
+      , candidateModules
+      }
   , qualifiers
   , maxResults
   , groupCompletions
@@ -93,9 +116,19 @@ getSuggestions _notify port
   if moduleExplicit then
     case match' explicitImportRegex line of
       Just [ Just _, Just mod, Just token ] -> do
-        let cc ns = Tuple ns <$> getCompletion' Nothing [ C.PrefixFilter token, C.NamespaceFilter [ ns ] ] port mainModule Nothing [ mod ] getQualifiedModule opts
+        let
+          cc ns = Tuple ns <$> getCompletion' Nothing
+            [ C.PrefixFilter token, C.NamespaceFilter [ ns ] ]
+            port
+            mainModule
+            Nothing
+            [ mod ]
+            getQualifiedModule
+            opts
         completions <- traverse cc [ C.NSValue, C.NSType ]
-        pure $ complete $ concatMap (\(Tuple n cs) -> result Nothing token (Just n) <$> cs) completions
+        pure $ complete $ concatMap
+          (\(Tuple n cs) -> result Nothing token (Just n) <$> cs)
+          completions
       _ -> pure $ complete []
   else
     case parsed of
@@ -105,14 +138,28 @@ getSuggestions _notify port
           completions <- getModuleSuggestions port prefix
           pure $ complete $ map (modResult prefix) completions
         else do
-          let cc ns = (map (Tuple ns)) <$> getCompletion' Nothing [ C.PrefixFilter token, C.NamespaceFilter [ ns ] ] port mainModule mod ("Prim" : modules) getQualifiedModule opts
-          completions :: Array (Array (Tuple Namespace TypeInfo)) <- traverse cc [ C.NSValue, C.NSType ]
           let
-            isIncomplete = any (\list -> Just (Array.length list) == maxResults) completions
-            completions' = simplifyImportChoice Tuple.snd $ Array.concat completions
+            cc ns = (map (Tuple ns)) <$> getCompletion' Nothing
+              [ C.PrefixFilter token, C.NamespaceFilter [ ns ] ]
+              port
+              mainModule
+              mod
+              ("Prim" : modules)
+              getQualifiedModule
+              opts
+          completions :: Array (Array (Tuple Namespace TypeInfo)) <- traverse cc
+            [ C.NSValue, C.NSType ]
+          let
+            isIncomplete = any (\list -> Just (Array.length list) == maxResults)
+              completions
+            completions' = simplifyImportChoice Tuple.snd $ Array.concat
+              completions
             results =
               matchingQualifiers mod token
-                <> ((\(Tuple n c) -> result mod token (Just n) c) <$> (takeExisting mod token $ completions'))
+                <>
+                  ( (\(Tuple n c) -> result mod token (Just n) c) <$>
+                      (takeExisting mod token $ completions')
+                  )
           pure { results, isIncomplete }
       Nothing -> pure $ complete []
   where
@@ -120,9 +167,12 @@ getSuggestions _notify port
   opts = CompletionOptions { maxResults, groupReexports: groupCompletions }
 
   matchingQualifiers (Just _) _ = []
-  matchingQualifiers Nothing token = convQ <$> Array.filter (\{ qualifier } -> indexOf (Pattern token) qualifier == Just 0) qualifiers
+  matchingQualifiers Nothing token = convQ <$> Array.filter
+    (\{ qualifier } -> indexOf (Pattern token) qualifier == Just 0)
+    qualifiers
     where
-    convQ { qualifier, moduleName } = QualifierSuggestion { text: qualifier, mod: moduleName }
+    convQ { qualifier, moduleName } = QualifierSuggestion
+      { text: qualifier, mod: moduleName }
 
   getModuleName "" token = token
   getModuleName mod token = mod <> "." <> token
@@ -135,7 +185,7 @@ getSuggestions _notify port
   parsed = case match' moduleRegex line of
     Just [ Just _, mod, tok ]
       | mod /= Nothing || tok /= Nothing ->
-        Just { mod, token: fromMaybe "" tok }
+          Just { mod, token: fromMaybe "" tok }
     _ -> Nothing
 
   takeExisting (Just _) _token completions = completions
@@ -143,7 +193,9 @@ getSuggestions _notify port
     Array.filter filterCompletion completions
     where
     ident (Tuple _ (TypeInfo { identifier })) = identifier
-    candidateModules' = Map.fromFoldable $ (\x -> Tuple x (Set.fromFoldable $ candidateModules x)) <$> Array.nub (ident <$> completions)
+    candidateModules' = Map.fromFoldable $
+      (\x -> Tuple x (Set.fromFoldable $ candidateModules x)) <$> Array.nub
+        (ident <$> completions)
 
     -- for each ident, the modules it may be imported from for some completion
     existingIdents =
@@ -153,7 +205,8 @@ getSuggestions _notify port
             ( \(Tuple _ (TypeInfo { identifier, module', exportedFrom })) ->
                 let
                   exportedModules = Set.fromFoldable $ module' : exportedFrom
-                  candidates = fromMaybe Set.empty (Map.lookup identifier candidateModules')
+                  candidates = fromMaybe Set.empty
+                    (Map.lookup identifier candidateModules')
                   matches = candidates `Set.intersection` exportedModules
                 in
                   Tuple identifier matches
@@ -161,9 +214,13 @@ getSuggestions _notify port
             completions
     -- Tuple x $ Set.fromFoldable $ candidateModules x) completions
     -- filter each completion according to the modules it came from compared to the modules we might have already imported from, in this or some other completion
-    filterCompletion (Tuple ns (TypeInfo { identifier, module', exportedFrom, declarationType })) =
+    filterCompletion
+      ( Tuple ns
+          (TypeInfo { identifier, module', exportedFrom, declarationType })
+      ) =
       let
-        resolvedNS = (declarationType >>= declarationTypeToNamespace) <|> Just ns
+        resolvedNS = (declarationType >>= declarationTypeToNamespace) <|> Just
+          ns
         isDctor = case resolvedNS of
           Just C.NSValue -> startsWithCapitalLetter identifier
           _ -> false
@@ -178,11 +235,36 @@ getSuggestions _notify port
             let
               exportedModules = Set.fromFoldable $ module' : exportedFrom
             in
-              not $ Set.isEmpty $ candidateMods `Set.intersection` exportedModules
+              not $ Set.isEmpty $ candidateMods `Set.intersection`
+                exportedModules
 
-  modResult prefix moduleName = ModuleSuggestion { text: moduleName, suggestType: Module, prefix }
-  result qualifier prefix ns (TypeInfo { type', identifier, module': origMod, exportedFrom, documentation, declarationType }) =
-    IdentSuggestion { origMod, exportMod, identifier, qualifier, suggestType, prefix, valueType: type', namespace: ns, exportedFrom, documentation }
+  modResult prefix moduleName = ModuleSuggestion
+    { text: moduleName, suggestType: Module, prefix }
+  result
+    qualifier
+    prefix
+    ns
+    ( TypeInfo
+        { type'
+        , identifier
+        , module': origMod
+        , exportedFrom
+        , documentation
+        , declarationType
+        }
+    ) =
+    IdentSuggestion
+      { origMod
+      , exportMod
+      , identifier
+      , qualifier
+      , suggestType
+      , prefix
+      , valueType: type'
+      , namespace: ns
+      , exportedFrom
+      , documentation
+      }
     where
     -- use the declaration type of the result if available, or the ns we filtered the request by if we're doing that
     resolvedNS = (declarationType >>= declarationTypeToNamespace) <|> ns
@@ -202,7 +284,8 @@ getSuggestions _notify port
     -- 3. Re-export from a prefix named module (e.g. Foo.Bar.Baz reexported from Foo.Bar) shortest first
     -- 4. Original module (if none of the previous rules apply, there are no re-exports, or either grouping
     --    is disabled or compiler version does not support it)
-    exportMod = fromMaybe origMod (preferredModule <|> existingModule <|> prefixModule)
+    exportMod = fromMaybe origMod
+      (preferredModule <|> existingModule <|> prefixModule)
     existingModule = head $ intersect importedModules exportedFrom
     preferredModule = head $ intersect preferredModules exportedFrom
     prefixModule =
@@ -232,7 +315,8 @@ simplifyImportChoice :: forall a. (a -> TypeInfo) -> Array a -> Array a
 simplifyImportChoice f before = foldl go [] before
   where
   go acc info =
-    if isType (f info) && any (f >>> isTheSameButDataConstructor (f info)) before then
+    if
+      isType (f info) && any (f >>> isTheSameButDataConstructor (f info)) before then
       acc
     else
       snoc acc info
@@ -243,20 +327,21 @@ simplifyImportChoice f before = foldl go [] before
 
   isDataConstructor = case _ of
     TypeInfo { declarationType: Just DeclDataConstructor } -> true
-    TypeInfo { declarationType: Just DeclValue, identifier } | startsWithCapitalLetter identifier -> true
+    TypeInfo { declarationType: Just DeclValue, identifier }
+      | startsWithCapitalLetter identifier -> true
     _ -> false
 
   -- We could have data Foo = X and data Bar = Foo, check the dctor Foo has some type that could conceivably be a dctor for Foo
   -- i.e. is a (possibly nullary) function to Foo
   dctorMatchesType typeName (TypeInfo { type' }) =
     endsWith ("-> " <> typeName) type'
-    || endsWith ("→ " <> typeName) type'
-    || typeName == type'
+      || endsWith ("→ " <> typeName) type'
+      || typeName == type'
 
   isTheSameButDataConstructor (TypeInfo ti1) info2@(TypeInfo ti2) =
     ti1.identifier
       == ti2.identifier
       && ti1.module'
-      == ti2.module'
+        == ti2.module'
       && isDataConstructor info2
       && dctorMatchesType ti1.identifier info2

--- a/src/IdePurescript/Exec.js
+++ b/src/IdePurescript/Exec.js
@@ -1,10 +1,14 @@
-import { writeFileSync } from 'fs';
+import { writeFileSync } from "fs";
 
-export function whichSyncImpl (options) {
-  var which = require('which');
+export function whichSyncImpl(options) {
+  var which = require("which");
   return function (path) {
-    return function() {
-      return which.sync(path, { all: true, path: options.path, pathExt: options.pathExt });
+    return function () {
+      return which.sync(path, {
+        all: true,
+        path: options.path,
+        pathExt: options.pathExt,
+      });
     };
   };
 }

--- a/src/IdePurescript/Exec.purs
+++ b/src/IdePurescript/Exec.purs
@@ -1,12 +1,10 @@
-module IdePurescript.Exec
-
-where
+module IdePurescript.Exec where
 
 import Prelude
 
 import Control.Alt ((<|>))
-import Data.Either (either, Either(..))
-import Data.Maybe (fromMaybe, maybe, Maybe(..))
+import Data.Either (Either(..), either)
+import Data.Maybe (Maybe(..), fromMaybe, maybe)
 import Data.Nullable (Nullable, toNullable)
 import Effect (Effect)
 import Effect.Aff (Aff)
@@ -23,11 +21,16 @@ findBins pathVar server = do
   findBins'
     { pathExt: Nothing
     , path: either (const Nothing) Just pathVar
-    , env: either (const Nothing) (Just <<< flip (Object.insert "PATH") env) pathVar
+    , env: either (const Nothing) (Just <<< flip (Object.insert "PATH") env)
+        pathVar
     }
     server
 
-findBinsNoVersion :: forall a. { path :: Maybe String, pathExt :: Maybe String | a } -> String -> Aff (Array Executable)
+findBinsNoVersion ::
+  forall a.
+  { path :: Maybe String, pathExt :: Maybe String | a } ->
+  String ->
+  Aff (Array Executable)
 findBinsNoVersion { path, pathExt } executable = do
   bins <- which' { path, pathExt } executable <|> pure []
   pure $ (\bin -> Executable bin Nothing) <$> bins
@@ -36,19 +39,25 @@ getPathVar :: Boolean -> String -> Effect (Either String String)
 getPathVar addNpmBin rootDir = do
   processPath <- lookupEnv "PATH"
   pure
-    $ if addNpmBin then
+    $
+      if addNpmBin then
         Right $ addNpmBinPath rootDir processPath
       else
         Left $ fromMaybe "" processPath
 
 addNpmBinPath :: String -> Maybe String -> String
 addNpmBinPath rootDir path =
-  Path.concat [ rootDir, "node_modules", ".bin" ] <> (maybe "" (Path.delimiter <> _) path)
+  Path.concat [ rootDir, "node_modules", ".bin" ] <>
+    (maybe "" (Path.delimiter <> _) path)
 
 foreign import whichSyncImpl ::
   { path :: Nullable String, pathExt :: Nullable String } ->
   String ->
   Effect (Array String)
 
-whichSync :: { path :: Maybe String, pathExt :: Maybe String } -> String -> Effect (Array String)
-whichSync { path, pathExt } = whichSyncImpl { path: toNullable path, pathExt: toNullable pathExt }
+whichSync ::
+  { path :: Maybe String, pathExt :: Maybe String } ->
+  String ->
+  Effect (Array String)
+whichSync { path, pathExt } = whichSyncImpl
+  { path: toNullable path, pathExt: toNullable pathExt }

--- a/src/IdePurescript/Modules.js
+++ b/src/IdePurescript/Modules.js
@@ -1,3 +1,3 @@
-export function tmpDir () {
+export function tmpDir() {
   return require("os").tmpdir();
 }

--- a/src/IdePurescript/PscErrors.purs
+++ b/src/IdePurescript/PscErrors.purs
@@ -1,14 +1,14 @@
 module IdePurescript.PscErrors where
 
 import Prelude
+
 import Data.Argonaut (class DecodeJson, decodeJson, (.:))
 import Data.Argonaut.Parser (jsonParser)
 import Data.Bifunctor (lmap)
 import Data.Either (Either)
 import PscIde.Command (RebuildError)
 
-newtype PscResult
-  = PscResult
+newtype PscResult = PscResult
   { warnings :: Array RebuildError
   , errors :: Array RebuildError
   }

--- a/src/IdePurescript/PscIdeServer.purs
+++ b/src/IdePurescript/PscIdeServer.purs
@@ -9,7 +9,8 @@ module IdePurescript.PscIdeServer
   ) where
 
 import Prelude
-import Data.Array (length, head)
+
+import Data.Array (head, length)
 import Data.Either (either)
 import Data.Int as Int
 import Data.Maybe (Maybe(Just, Nothing), isNothing, maybe)
@@ -18,7 +19,7 @@ import Data.Traversable (traverse)
 import Effect (Effect)
 import Effect.Aff (Aff, attempt, try)
 import Effect.Class (liftEffect)
-import IdePurescript.Exec (getPathVar, findBins)
+import IdePurescript.Exec (findBins, getPathVar)
 import IdePurescript.PscIde (cwd) as PscIde
 import Node.ChildProcess (ChildProcess, stderr, stdout)
 import Node.Encoding (Encoding(..))
@@ -29,8 +30,7 @@ import Node.Stream (onDataString)
 import PscIde.Server (Executable(Executable), LogLevel, defaultServerArgs, getSavedPort, pickFreshPort, savePort)
 import PscIde.Server as S
 
-type Port
-  = Int
+type Port = Int
 
 data ServerStartResult
   = CorrectPath Port
@@ -44,17 +44,16 @@ data ErrorLevel
   | Info
   | Warning
   | Error
+
 instance showErrorLevel :: Show ErrorLevel where
   show Success = "Success"
   show Info = "Info"
   show Warning = "Warning"
   show Error = "Error"
 
-type Notify
-  = ErrorLevel -> String -> Effect Unit
+type Notify = ErrorLevel -> String -> Effect Unit
 
-data Version
-  = Version Int Int Int
+data Version = Version Int Int Int
 
 parseVersion :: String -> Maybe Version
 parseVersion s =
@@ -66,19 +65,20 @@ instance eqVersion :: Eq Version where
   eq (Version a b c) (Version a' b' c') = a == a' && b == b' && c == c'
 
 instance ordVersion :: Ord Version where
-  compare (Version a b c) (Version a' b' c') = compare [ a, b, c ] [ a', b', c' ]
+  compare (Version a b c) (Version a' b' c') = compare [ a, b, c ]
+    [ a', b', c' ]
 
 instance showVersion :: Show Version where
   show (Version a b c) = show a <> "." <> show b <> "." <> show c
 
-type ServerSettings
-  = { exe :: String
-    , combinedExe :: Boolean
-    , glob :: Array String
-    , logLevel :: Maybe LogLevel
-    , outputDirectory :: Maybe String
-    , port :: Maybe Int
-    }
+type ServerSettings =
+  { exe :: String
+  , combinedExe :: Boolean
+  , glob :: Array String
+  , logLevel :: Maybe LogLevel
+  , outputDirectory :: Maybe String
+  , port :: Maybe Int
+  }
 
 -- | Start a psc-ide server instance, or find one already running on the expected port, checking if it has the right path.
 -- | Will notify as to what is happening, choose to supply globs appropriately
@@ -96,37 +96,42 @@ startServer' settings@({ exe: server }) path addNpmBin cb logCb = do
     $ when (length serverBins > 1)
     $ cb Warning
     $ "Found multiple IDE server executables (will use the first one):\n"
-    <> joinWith "\n" (serverBins <#> printSrvExec)
+        <> joinWith "\n" (serverBins <#> printSrvExec)
   case head serverBins of
     Nothing -> do
       liftEffect
         $ cb Info
         $ "Couldn't find IDE server, check PATH env variable. Looked for: "
-        <> server
-        <> " in PATH: "
-        <> either identity identity pathVar
+            <> server
+            <> " in PATH: "
+            <> either identity identity pathVar
       pure { quit: pure unit, port: Nothing }
     Just srvExec@(Executable bin _version) -> do
       liftEffect
         $ logCb Info
         $ "Using found IDE server bin (npm-bin: "
-        <> show addNpmBin
-        <> "): "
-        <> printSrvExec srvExec
+            <> show addNpmBin
+            <> "): "
+            <> printSrvExec srvExec
       res <- startServer logCb (settings { exe = bin }) path
       let noRes = { quit: pure unit, port: Nothing }
       liftEffect
         $ case res of
-            CorrectPath usedPort -> { quit: pure unit, port: Just usedPort } <$ cb Info ("Found existing IDE server with correct path on port " <> show usedPort)
+            CorrectPath usedPort -> { quit: pure unit, port: Just usedPort } <$
+              cb Info
+                ( "Found existing IDE server with correct path on port " <> show
+                    usedPort
+                )
             WrongPath usedPort wrongPath expectedPath -> do
               cb Error
                 $ "Found existing IDE server on port '"
-                <> show usedPort
-                <> "' with wrong path: '"
-                <> wrongPath
-                <> "' instead of '"
-                <> expectedPath
-                <> "'. Correct, kill or configure a different port, and restart."
+                    <> show usedPort
+                    <> "' with wrong path: '"
+                    <> wrongPath
+                    <> "' instead of '"
+                    <> expectedPath
+                    <>
+                      "'. Correct, kill or configure a different port, and restart."
               pure noRes
             Started usedPort cp -> do
               cb Success $ "Started IDE server (port " <> show usedPort <> ")"
@@ -136,13 +141,19 @@ startServer' settings@({ exe: server }) path addNpmBin cb logCb = do
                 , port: Just usedPort
                 }
             Closed -> noRes <$ cb Info "IDE server exited with success code"
-            StartError err -> noRes <$ (cb Error $ "Could not start IDE server process. Check the configured port number is valid.\n" <> err)
+            StartError err -> noRes <$
+              ( cb Error $
+                  "Could not start IDE server process. Check the configured port number is valid.\n"
+                    <> err
+              )
   where
   printSrvExec (Executable bin' mbVer) =
     bin'
       <> ":"
       <> maybe " could not determine version"
-          (\v -> " " <> trim v <> "") mbVer
+        (\v -> " " <> trim v <> "")
+        mbVer
+
   wireOutput :: ChildProcess -> Notify -> Effect Unit
   wireOutput cp log = do
     onDataString (stderr cp) UTF8 (log Warning)
@@ -150,45 +161,53 @@ startServer' settings@({ exe: server }) path addNpmBin cb logCb = do
 
 -- | Start a psc-ide server instance, or find one already running on the expected port, checking if it has the right path.
 startServer :: Notify -> ServerSettings -> String -> Aff ServerStartResult
-startServer logCb { exe, combinedExe, glob, logLevel, outputDirectory, port: configuredPort } rootPath = do
+startServer
+  logCb
+  { exe, combinedExe, glob, logLevel, outputDirectory, port: configuredPort }
+  rootPath = do
   case configuredPort of
     -- Connect to existing server or launch one on this port
     Just port -> joinServer port configuredPort "Using configured port"
     Nothing ->
       (liftEffect $ getSavedPort rootPath)
         >>= case _ of
-            -- Connect to existing server on this port or launch one on new port
-            Just port -> joinServer port Nothing "Found existing port from file"
-            -- Launch on new port
-            Nothing -> launchServer Nothing
+          -- Connect to existing server on this port or launch one on new port
+          Just port -> joinServer port Nothing "Found existing port from file"
+          -- Launch on new port
+          Nothing -> launchServer Nothing
 
   where
 
   joinServer :: Int -> Maybe Int -> String -> Aff ServerStartResult
   joinServer port launchPort message = do
     workingDir <- attempt $ PscIde.cwd port
-    liftEffect $ logCb Info $ message <> ": " <> show port <> (either (const " (couldn't connect to existing server)") (", cwd: " <> _) workingDir)
+    liftEffect $ logCb Info $ message <> ": " <> show port <>
+      ( either (const " (couldn't connect to existing server)") (", cwd: " <> _)
+          workingDir
+      )
     either (const $ launchServer launchPort) (gotPath port) workingDir
 
   launchServer connectPort = do
     port <- maybe (liftEffect pickFreshPort) pure connectPort
     liftEffect
       $ do
-          logCb Info $ "Starting IDE server on port " <> show port <> " with cwd " <> rootPath
+          logCb Info $ "Starting IDE server on port " <> show port
+            <> " with cwd "
+            <> rootPath
           -- Save it just if we picked it
           when (isNothing connectPort) $ savePort port rootPath
     r port
       <$> S.startServer
-          ( defaultServerArgs
-              { exe = exe
-              , combinedExe = combinedExe
-              , cwd = Just rootPath
-              , port = Just port
-              , source = glob
-              , logLevel = logLevel
-              , outputDirectory = outputDirectory
-              }
-          )
+        ( defaultServerArgs
+            { exe = exe
+            , combinedExe = combinedExe
+            , cwd = Just rootPath
+            , port = Just port
+            , source = glob
+            , logLevel = logLevel
+            , outputDirectory = outputDirectory
+            }
+        )
     where
     r port (S.Started cp) = Started port cp
     r _ (S.Closed) = Closed
@@ -196,18 +215,27 @@ startServer logCb { exe, combinedExe, glob, logLevel, outputDirectory, port: con
 
   gotPath port workingDir =
     liftEffect
-      $ if normalizePath workingDir == normalizePath rootPath then do
-          logCb Info $ "Found IDE server on port " <> show port <> " with correct path: " <> workingDir
+      $
+        if normalizePath workingDir == normalizePath rootPath then do
+          logCb Info $ "Found IDE server on port " <> show port
+            <> " with correct path: "
+            <> workingDir
           pure $ CorrectPath port
         else do
-          logCb Info $ "Found IDE server on port " <> show port <> " with wrong path: " <> normalizePath workingDir <> " instead of " <> normalizePath rootPath
+          logCb Info $ "Found IDE server on port " <> show port
+            <> " with wrong path: "
+            <> normalizePath workingDir
+            <> " instead of "
+            <> normalizePath rootPath
           pure $ WrongPath port workingDir rootPath
 
-  normalizePath = (if platform == Just Win32 then toLower else identity) <<< normalize
+  normalizePath = (if platform == Just Win32 then toLower else identity) <<<
+    normalize
 
 -- | Stop a psc-ide server. Currently implemented by asking it nicely, but potentially by killing it if that doesn't work...
 stopServer :: Int -> String -> ChildProcess -> Aff Unit
 stopServer port rootPath _cp = do
   oldPort <- liftEffect $ S.getSavedPort rootPath
-  _ <- try $ liftEffect $ when (oldPort == Just port) $ S.deleteSavedPort rootPath
+  _ <- try $ liftEffect $ when (oldPort == Just port) $ S.deleteSavedPort
+    rootPath
   S.stopServer port

--- a/src/IdePurescript/PscIdeServer.purs
+++ b/src/IdePurescript/PscIdeServer.purs
@@ -80,8 +80,9 @@ type ServerSettings =
   , port :: Maybe Int
   }
 
--- | Start a psc-ide server instance, or find one already running on the expected port, checking if it has the right path.
--- | Will notify as to what is happening, choose to supply globs appropriately
+-- | Start a psc-ide server instance, or find one already running on the
+-- | expected port, checking if it has the right path. Will notify as to what is
+-- | happening, choose to supply globs appropriately
 startServer' ::
   ServerSettings ->
   String ->
@@ -93,6 +94,9 @@ startServer' settings@({ exe: server }) path addNpmBin cb logCb = do
   pathVar <- liftEffect $ getPathVar addNpmBin path
   serverBins <- findBins pathVar server
   liftEffect
+    $ cb Info
+    $ "Using PATH env variable value: " <> either identity identity pathVar
+  liftEffect
     $ when (length serverBins > 1)
     $ cb Warning
     $ "Found multiple IDE server executables (will use the first one):\n"
@@ -101,10 +105,9 @@ startServer' settings@({ exe: server }) path addNpmBin cb logCb = do
     Nothing -> do
       liftEffect
         $ cb Info
-        $ "Couldn't find IDE server, check PATH env variable. Looked for: "
+        $ "Couldn't find IDE server, looked for: "
             <> server
-            <> " in PATH: "
-            <> either identity identity pathVar
+            <> " using PATH env variable."
       pure { quit: pure unit, port: Nothing }
     Just srvExec@(Executable bin _version) -> do
       liftEffect

--- a/src/IdePurescript/QuickFix.purs
+++ b/src/IdePurescript/QuickFix.purs
@@ -1,6 +1,7 @@
 module IdePurescript.QuickFix where
 
 import Prelude
+
 import Data.Foldable (elem)
 
 -- | Get a title which explains what applying a compiler suggestion will do
@@ -18,7 +19,8 @@ getTitle code = case code of
 wildcardInferredType :: String
 wildcardInferredType = "WildcardInferredType"
 
--- | Determine whether an error code represents an unknown token (unknown identifier or missing import)
+-- | Determine whether an error code represents an unknown token (unknown
+-- | identifier or missing import)
 isUnknownToken :: String -> Boolean
 isUnknownToken =
   flip elem

--- a/src/IdePurescript/Regex.purs
+++ b/src/IdePurescript/Regex.purs
@@ -1,6 +1,7 @@
 module IdePurescript.Regex where
 
 import Prelude
+
 import Data.Array.NonEmpty as NEA
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))

--- a/src/IdePurescript/Tokens.purs
+++ b/src/IdePurescript/Tokens.purs
@@ -1,6 +1,7 @@
 module IdePurescript.Tokens where
 
 import Prelude
+
 import Data.Either (Either)
 import Data.Maybe (Maybe(..))
 import Data.Newtype (un)
@@ -12,8 +13,7 @@ import PureScript.CST.Lexer as CST.Lexer
 import PureScript.CST.TokenStream as TokenStream
 import PureScript.CST.Types (ModuleName(..), Token(..))
 
-type WordRange
-  = { left :: Int, right :: Int }
+type WordRange = { left :: Int, right :: Int }
 
 -- Regexes still used by Completion
 modulePart :: String
@@ -28,11 +28,22 @@ moduleRegex = regex (modulePrefix <> "?" <> identPart <> "?$") noFlags
   modulePrefix :: String
   modulePrefix = "(?:^|[^A-Za-z_.])(?:" <> modulePart <> """\.)"""
 
-identifierAtPoint :: String -> Int -> Maybe { word :: String, range :: WordRange, qualifier :: Maybe String }
+identifierAtPoint ::
+  String ->
+  Int ->
+  Maybe { word :: String, range :: WordRange, qualifier :: Maybe String }
 identifierAtPoint line column =
   go $ TokenStream.step $ CST.Lexer.lex line
   where
-  go (TokenStream.TokenCons { range: { start: { column: startCol }, end: { column: endCol } }, value } _ str _) =
+  go
+    ( TokenStream.TokenCons
+        { range: { start: { column: startCol }, end: { column: endCol } }
+        , value
+        }
+        _
+        str
+        _
+    ) =
     if column < startCol then
       Nothing
     else if column >= endCol then

--- a/src/LanguageServer/IdePurescript/Assist.purs
+++ b/src/LanguageServer/IdePurescript/Assist.purs
@@ -8,8 +8,7 @@ module LanguageServer.IdePurescript.Assist
   , fixTypo
   , fixTypoActions
   , lineRange'
-  )
-  where
+  ) where
 
 import Prelude
 
@@ -53,54 +52,72 @@ lineRange pos =
     , end: pos # over Position (_ { character = (top :: Int) })
     }
 
-caseSplit :: DocumentStore -> Settings -> ServerState -> Array Foreign -> Aff Unit
+caseSplit ::
+  DocumentStore -> Settings -> ServerState -> Array Foreign -> Aff Unit
 caseSplit docs _ state args = do
   let ServerState { port, conn, clientCapabilities } = state
   case port, conn, args of
     Just port', Just conn', [ argUri, argLine, argChar, argType ]
       | Right uri <- runExcept $ readString argUri
-      , Right line <- runExcept $ readInt argLine -- TODO: Can this be a Position?
+      , Right line <-
+          runExcept $ readInt argLine -- TODO: Can this be a Position?
       , Right char <- runExcept $ readInt argChar
       , Right tyStr <- runExcept $ readString argType -> do
-        doc <- liftEffect $ getDocument docs (DocumentUri uri)
-        for_ (Nullable.toMaybe doc) \doc -> do
-          lineText <- liftEffect $ getTextAtRange doc (lineRange' line char)
-          version <- liftEffect $ getVersion doc
-          case identifierAtPoint lineText char of
-            Just { range: { left, right } } -> do
-              lines <- eitherToErr $ P.caseSplit port' lineText left right false tyStr
-              let edit = makeWorkspaceEdit clientCapabilities (DocumentUri uri) version (lineRange' line char) $ intercalate "\n" $ map trim lines
-              void $ applyEdit conn' edit
-            _ -> do
-              liftEffect $ log conn' "fail identifier"
+          doc <- liftEffect $ getDocument docs (DocumentUri uri)
+          for_ (Nullable.toMaybe doc) \doc -> do
+            lineText <- liftEffect $ getTextAtRange doc (lineRange' line char)
+            version <- liftEffect $ getVersion doc
+            case identifierAtPoint lineText char of
+              Just { range: { left, right } } -> do
+                lines <- eitherToErr $ P.caseSplit port' lineText left right
+                  false
+                  tyStr
+                let
+                  edit =
+                    makeWorkspaceEdit clientCapabilities (DocumentUri uri)
+                      version
+                      (lineRange' line char) $ intercalate "\n" $ map trim lines
+                void $ applyEdit conn' edit
+              _ -> do
+                liftEffect $ log conn' "fail identifier"
     _, Just conn', [ argUri, argLine, argChar, argType ] ->
-      liftEffect $ log conn' $ show [ show $ runExcept $ readString argUri, show $ runExcept $ readInt argLine, show $ runExcept $ readInt argChar, show $ runExcept $ readString argType ]
+      liftEffect $ log conn' $ show
+        [ show $ runExcept $ readString argUri
+        , show $ runExcept $ readInt argLine
+        , show $ runExcept $ readInt argChar
+        , show $ runExcept $ readString argType
+        ]
     _, _, _ -> do
       liftEffect $ maybe (pure unit) (flip log "fail match") conn
       pure unit
 
-addClause :: DocumentStore -> Settings -> ServerState -> Array Foreign -> Aff Unit
+addClause ::
+  DocumentStore -> Settings -> ServerState -> Array Foreign -> Aff Unit
 addClause docs _ state args = do
   let ServerState { port, conn, clientCapabilities } = state
   case port, conn, args of
     Just port', Just conn', [ argUri, argLine, argChar ]
       | Right uri <- runExcept $ readString argUri
-      , Right line <- runExcept $ readInt argLine -- TODO: Can this be a Position?
+      , Right line <-
+          runExcept $ readInt argLine -- TODO: Can this be a Position?
       , Right char <- runExcept $ readInt argChar -> do
-        doc <- liftEffect $ getDocument docs (DocumentUri uri)
-        for_ (Nullable.toMaybe doc) \doc -> do
-          lineText <- liftEffect $ getTextAtRange doc (lineRange' line char)
-          version <- liftEffect $ getVersion doc
-          case identifierAtPoint lineText char of
-            Just _ -> do
-              lines <- eitherToErr $ P.addClause port' lineText false
-              let edit = makeWorkspaceEdit clientCapabilities (DocumentUri uri) version (lineRange' line char) $ intercalate "\n" $ map trim lines
-              void $ applyEdit conn' edit
-            _ -> pure unit
+          doc <- liftEffect $ getDocument docs (DocumentUri uri)
+          for_ (Nullable.toMaybe doc) \doc -> do
+            lineText <- liftEffect $ getTextAtRange doc (lineRange' line char)
+            version <- liftEffect $ getVersion doc
+            case identifierAtPoint lineText char of
+              Just _ -> do
+                lines <- eitherToErr $ P.addClause port' lineText false
+                let
+                  edit =
+                    makeWorkspaceEdit clientCapabilities (DocumentUri uri)
+                      version
+                      (lineRange' line char) $ intercalate "\n" $ map trim lines
+                void $ applyEdit conn' edit
+              _ -> pure unit
     _, _, _ -> pure unit
 
-newtype TypoResult
-  = TypoResult
+newtype TypoResult = TypoResult
   { identifier :: String
   , mod :: String
   , declarationType :: String
@@ -108,7 +125,8 @@ newtype TypoResult
   }
 
 encodeTypoResult :: TypoResult -> Foreign
-encodeTypoResult (TypoResult res) = unsafeToForeign (res { qualifier = Nullable.toNullable $ res.qualifier })
+encodeTypoResult (TypoResult res) = unsafeToForeign
+  (res { qualifier = Nullable.toNullable $ res.qualifier })
 
 decodeTypoResult :: Foreign -> F TypoResult
 decodeTypoResult obj = do
@@ -120,7 +138,14 @@ decodeTypoResult obj = do
   qualifier <- obj ! "qualifier" >>= readNullOrUndefined readString
   pure $ TypoResult { identifier, qualifier, mod, declarationType }
 
-fixTypoActions :: DocumentStore -> Settings -> ServerState -> DocumentUri -> Int -> Int -> Aff (Array Command)
+fixTypoActions ::
+  DocumentStore ->
+  Settings ->
+  ServerState ->
+  DocumentUri ->
+  Int ->
+  Int ->
+  Aff (Array Command)
 fixTypoActions docs _ (ServerState { port, conn, modules }) docUri line char =
   case port, conn of
     Just port', Just _ -> do
@@ -129,25 +154,43 @@ fixTypoActions docs _ (ServerState { port, conn, modules }) docUri line char =
         lineText <- liftEffect $ getTextAtRange doc (lineRange' line char)
         case identifierAtPoint lineText char of
           Just { word, qualifier } -> do
-            res <- suggestTypos port' word 2 modules.main defaultCompletionOptions
+            res <- suggestTypos port' word 2 modules.main
+              defaultCompletionOptions
             pure
               $ case res of
                   Left _ -> []
                   Right infos ->
                     infos
                       # simplifyImportChoice identity
-                      <#> ( \(TypeInfo { type', identifier, module', declarationType }) ->
-                            Commands.fixTypo' 
-                              (
-                                let decTypeString = renderDeclarationType type' identifier declarationType
+                      <#>
+                        ( \( TypeInfo
+                               { type', identifier, module', declarationType }
+                           ) ->
+                            Commands.fixTypo'
+                              ( let
+                                  decTypeString = renderDeclarationType type'
+                                    identifier
+                                    declarationType
                                 in
-                                if identifier == word then
-                                  "Import" <> decTypeString <> identifier <> " (" <> module' <> ")"
-                                else
-                                  "Replace with " <> identifier <> " (" <> module' <> ")"
+                                  if identifier == word then
+                                    "Import" <> decTypeString <> identifier
+                                      <> " (" <> module' <> ")"
+                                  else
+                                    "Replace with " <> identifier
+                                      <> " (" <> module' <> ")"
                               )
-                              docUri line char
-                              (encodeTypoResult $ TypoResult { identifier, qualifier, mod: module', declarationType: maybe "" declarationTypeToString declarationType })
+                              docUri
+                              line
+                              char
+                              ( encodeTypoResult $ TypoResult
+                                  { identifier
+                                  , qualifier
+                                  , mod: module'
+                                  , declarationType: maybe ""
+                                      declarationTypeToString
+                                      declarationType
+                                  }
+                              )
                         )
                       # take 10
           Nothing -> pure []
@@ -170,38 +213,76 @@ fixTypoActions docs _ (ServerState { port, conn, modules }) docUri line char =
       else
         " value: "
 
-fixTypo :: Notify -> DocumentStore -> Settings -> ServerState -> Array Foreign -> Aff Foreign
-fixTypo log docs settings state@(ServerState { port, conn, clientCapabilities }) args = do
+fixTypo ::
+  Notify ->
+  DocumentStore ->
+  Settings ->
+  ServerState ->
+  Array Foreign ->
+  Aff Foreign
+fixTypo
+  log
+  docs
+  settings
+  state@(ServerState { port, conn, clientCapabilities })
+  args = do
   unsafeToForeign
     <$> case port, conn, args !! 0, args !! 1, args !! 2 of
         Just _, Just _, Just argUri, Just argLine, Just argChar
           | Right uri <- runExcept $ readString argUri
-          , Right line <- runExcept $ readInt argLine -- TODO: Can this be a Position?
+          , Right line <-
+              runExcept $ readInt argLine -- TODO: Can this be a Position?
           , Right char <- runExcept $ readInt argChar -> do
-            doc <- liftEffect $ getDocument docs (DocumentUri uri)
-            for_ (Nullable.toMaybe doc) \doc -> do
-              lineText <- liftEffect $ getTextAtRange doc (lineRange' line char)
-              version <- liftEffect $ getVersion doc
-              case identifierAtPoint lineText char, (runExcept <<< decodeTypoResult) <$> args !! 3 of
-                Just { range }, Just (Right (TypoResult { identifier, qualifier, mod, declarationType })) -> do
-                  void $ replace uri version line range identifier qualifier mod declarationType
-                _, _ -> pure unit
+              doc <- liftEffect $ getDocument docs (DocumentUri uri)
+              for_ (Nullable.toMaybe doc) \doc -> do
+                lineText <- liftEffect $ getTextAtRange doc (lineRange' line char)
+                version <- liftEffect $ getVersion doc
+                case
+                  identifierAtPoint lineText char,
+                  (runExcept <<< decodeTypoResult) <$> args !! 3
+                  of
+                  Just { range },
+                  Just
+                    ( Right
+                        ( TypoResult
+                            { identifier, qualifier, mod, declarationType }
+                        )
+                    ) -> do
+                    void $ replace uri version line range identifier qualifier mod
+                      declarationType
+                  _, _ -> pure unit
         _, _, _, _, _ -> pure unit
 
   where
-  replace uri version line { left, right } word qualifier mod declarationType = do
-    let
-      range =
-        Range
-          { start: Position { line, character: left }
-          , end: Position { line, character: right }
-          }
-      edit = makeWorkspaceEdit clientCapabilities (DocumentUri uri) version range $ maybe "" (_ <> ".") qualifier <> word
-      -- TODO suggestion type
-      namespace = declarationTypeToNamespace =<< declarationTypeFromString declarationType
-    addCompletionImport' edit log docs settings state [ unsafeToForeign word, unsafeToForeign mod, unsafeToForeign $ Nullable.toNullable qualifier, unsafeToForeign uri, unsafeToForeign (maybe "" showNS namespace) ]
+  replace uri version line { left, right } word qualifier mod declarationType =
+    do
+      let
+        range =
+          Range
+            { start: Position { line, character: left }
+            , end: Position { line, character: right }
+            }
+        edit =
+          makeWorkspaceEdit clientCapabilities (DocumentUri uri) version range $
+            maybe "" (_ <> ".") qualifier <> word
+        -- TODO suggestion type
+        namespace = declarationTypeToNamespace =<< declarationTypeFromString
+          declarationType
+      addCompletionImport' edit log docs settings state
+        [ unsafeToForeign word
+        , unsafeToForeign mod
+        , unsafeToForeign $ Nullable.toNullable qualifier
+        , unsafeToForeign uri
+        , unsafeToForeign (maybe "" showNS namespace)
+        ]
 
-fillTypedHole :: Notify -> DocumentStore -> Settings -> ServerState -> Array Foreign -> Aff Unit
+fillTypedHole ::
+  Notify ->
+  DocumentStore ->
+  Settings ->
+  ServerState ->
+  Array Foreign ->
+  Aff Unit
 fillTypedHole logFn docs settings state args = do
   let ServerState { port, conn, clientCapabilities } = state
   case port, conn, args of
@@ -209,22 +290,38 @@ fillTypedHole logFn docs settings state args = do
       | Right range <- runExcept $ readRange range'
       , Right uri <- runExcept $ readString argUri
       , TypeInfo { identifier, module': mod } <- readTypeInfo argChoice -> do
-        doc <- liftEffect $ getDocument docs (DocumentUri uri)
-        for_ (Nullable.toMaybe doc) \doc -> do
-          { text, version } <- liftEffect $ getTextAtVersion doc
-          let edit = makeWorkspaceEdit clientCapabilities (DocumentUri uri) version range identifier
-          edit' <-
-            either (const []) identity
-              <$> addCompletionImportEdit logFn docs settings state
-                  { identifier, mod: Just mod, qual: Nothing, uri: DocumentUri uri }
-                  doc version text Nothing
-          let edit2 = edit <> fold edit'
-          applyRes <- applyEdit conn' $ edit2 -- edit <> fold edit'
-          liftEffect $ log conn' $ "Applied: " <> show applyRes
-          -- -- Seems that even after waiting for the edit response, changes will be lost 
-          -- delay $ Milliseconds 300.0
-          _ <- addCompletionImport logFn docs settings state [ unsafeToForeign identifier, unsafeToForeign mod, unsafeToForeign Nothing, unsafeToForeign uri ]
-          pure unit
+          doc <- liftEffect $ getDocument docs (DocumentUri uri)
+          for_ (Nullable.toMaybe doc) \doc -> do
+            { text, version } <- liftEffect $ getTextAtVersion doc
+            let
+              edit = makeWorkspaceEdit clientCapabilities (DocumentUri uri)
+                version
+                range
+                identifier
+            edit' <-
+              either (const []) identity
+                <$> addCompletionImportEdit logFn docs settings state
+                    { identifier
+                    , mod: Just mod
+                    , qual: Nothing
+                    , uri: DocumentUri uri
+                    }
+                    doc
+                    version
+                    text
+                    Nothing
+            let edit2 = edit <> fold edit'
+            applyRes <- applyEdit conn' $ edit2 -- edit <> fold edit'
+            liftEffect $ log conn' $ "Applied: " <> show applyRes
+            -- -- Seems that even after waiting for the edit response, changes will be lost
+            -- delay $ Milliseconds 300.0
+            _ <- addCompletionImport logFn docs settings state
+              [ unsafeToForeign identifier
+              , unsafeToForeign mod
+              , unsafeToForeign Nothing
+              , unsafeToForeign uri
+              ]
+            pure unit
     _, _, _ -> do
       liftEffect $ maybe (pure unit) (flip log "fail match") conn
       pure unit

--- a/src/LanguageServer/IdePurescript/Build.js
+++ b/src/LanguageServer/IdePurescript/Build.js
@@ -1,14 +1,14 @@
-export function parseShellQuote (str) {
+export function parseShellQuote(str) {
   return require("shell-quote").parse(str);
 }
 
 export function getOsTmpDir() {
   return require("os").tmpdir();
-};
+}
 
 export function getHash(str) {
   return require("crypto").createHash("sha256").update(str).digest("hex");
-};
+}
 
 export const copyFile = (src) => (dest) => {
   return () => {

--- a/src/LanguageServer/IdePurescript/Clean.purs
+++ b/src/LanguageServer/IdePurescript/Clean.purs
@@ -1,7 +1,6 @@
 module LanguageServer.IdePurescript.Clean
   ( clean
-  )
-  where
+  ) where
 
 import Prelude
 
@@ -23,17 +22,20 @@ clean settings = do
     outputDir = effectiveOutputDirectory settings
   attempedStats <- attempt $ FS.stat outputDir
   case attempedStats of
-    Left err -> pure $ Left $ "Could not find directory to clean. " <> message err
+    Left err -> pure $ Left $ "Could not find directory to clean. " <> message
+      err
     Right stats -> case isDirectory stats of
       false -> pure $ Left $ "Target \"" <> outputDir <> "\" is not a directory"
       true -> do
         msg <- (processDir false) outputDir
         case length msg of
-          0 -> pure $ Right $ "Nothing to clean in directory \"" <> outputDir <> "\""
-          _ -> pure $ Right $ msg <> "Successfully cleaned directory \"" <> outputDir <> "\""
+          0 -> pure $ Right $ "Nothing to clean in directory \"" <> outputDir <>
+            "\""
+          _ -> pure $ Right $ msg <> "Successfully cleaned directory \""
+            <> outputDir
+            <> "\""
 
-type Processor
-  = Boolean -> Path.FilePath -> Aff String
+type Processor = Boolean -> Path.FilePath -> Aff String
 
 processDir :: Processor
 processDir markedForRemoval path = do
@@ -74,17 +76,20 @@ filesToRemove :: Array Path.FilePath
 filesToRemove = [ "cache-db.json" ]
 
 maybeRemovableFile :: Path.FilePath -> Maybe Path.FilePath
-maybeRemovableFile filePath = find (\x -> x == (Path.basename filePath)) filesToRemove
+maybeRemovableFile filePath = find (\x -> x == (Path.basename filePath))
+  filesToRemove
 
 directoryRemovalMarker :: Path.FilePath
 directoryRemovalMarker = "externs.cbor"
 
 maybeRemovableContents :: Array Path.FilePath -> Maybe (Array Path.FilePath)
-maybeRemovableContents dirContents = case find (\x -> x == directoryRemovalMarker) dirContents of
-  Nothing -> Nothing
-  _ -> Just dirContents
+maybeRemovableContents dirContents =
+  case find (\x -> x == directoryRemovalMarker) dirContents of
+    Nothing -> Nothing
+    _ -> Just dirContents
 
-removeDirectory :: Processor -> Path.FilePath -> Array Path.FilePath -> Aff String
+removeDirectory ::
+  Processor -> Path.FilePath -> Array Path.FilePath -> Aff String
 removeDirectory processor dirPath contentFullPaths = do
   let
     dirRemovalMsg :: String

--- a/src/LanguageServer/IdePurescript/CodeActions.purs
+++ b/src/LanguageServer/IdePurescript/CodeActions.purs
@@ -2,8 +2,7 @@ module LanguageServer.IdePurescript.CodeActions
   ( getActions
   , onReplaceAllSuggestions
   , onReplaceSuggestion
-  )
-  where
+  ) where
 
 import Prelude
 
@@ -11,8 +10,8 @@ import Control.Monad.Except (runExcept)
 import Data.Array (catMaybes, concat, filter, foldl, head, length, mapMaybe, nubByEq, singleton, sortWith, (:))
 import Data.Array as Array
 import Data.Either (Either(..))
-import Data.Maybe (Maybe(..), fromMaybe, isJust, maybe)
 import Data.Map as Map
+import Data.Maybe (Maybe(..), fromMaybe, isJust, maybe)
 import Data.Newtype (un)
 import Data.Nullable as Nullable
 import Data.String (Pattern(..))
@@ -36,26 +35,39 @@ import LanguageServer.Protocol.DocumentStore (getDocument)
 import LanguageServer.Protocol.Handlers (CodeActionParams, applyEdit)
 import LanguageServer.Protocol.Text (makeWorkspaceEdit)
 import LanguageServer.Protocol.TextDocument (TextDocument, getTextAtRange, getVersion)
-import LanguageServer.Protocol.TextDocument (TextDocument, getTextAtRange, getVersion)
 import LanguageServer.Protocol.Types (ClientCapabilities, CodeAction(..), CodeActionKind(..), CodeActionResult, Command(..), DocumentStore, DocumentUri(DocumentUri), OptionalVersionedTextDocumentIdentifier(..), Position(Position), Range(Range), Settings, TextDocumentEdit(..), TextDocumentIdentifier(TextDocumentIdentifier), TextEdit(..), codeActionEmpty, codeActionResult, codeActionSourceOrganizeImports, codeActionSourceSortImports, readRange, workspaceEdit)
-import LanguageServer.Protocol.Types (ClientCapabilities, CodeAction(..), CodeActionKind(..), CodeActionResult, Command(..), DocumentStore, DocumentUri(DocumentUri), OptionalVersionedTextDocumentIdentifier(..), Position(Position), Range(Range), Settings, TextDocumentEdit(..), TextDocumentIdentifier(TextDocumentIdentifier), TextEdit(..), codeActionEmpty, codeActionResult, codeActionSourceOrganizeImports, codeActionSourceSortImports, readRange, workspaceEdit)
-import PscIde.Command (PscSuggestion(..), PursIdeInfo(..), RebuildError(..))
 import PscIde.Command (PscSuggestion(..), PursIdeInfo(..), RebuildError(..))
 
-getActions :: DocumentStore -> Settings -> ServerState -> CodeActionParams -> Aff (Array CodeActionResult)
-getActions documents settings state@(ServerState { diagnostics, conn: Just _conn, clientCapabilities }) { textDocument, range, context: { only }  } =
+getActions ::
+  DocumentStore ->
+  Settings ->
+  ServerState ->
+  CodeActionParams ->
+  Aff (Array CodeActionResult)
+getActions
+  documents
+  settings
+  state@(ServerState { diagnostics, conn: Just _conn, clientCapabilities })
+  { textDocument, range, context: { only } } =
   case Map.lookup docUri diagnostics of
     Just { errors: errs } ->
       mapMaybe (codeActionToCommand clientCapabilities)
         <$> do
-            codeActions :: Array (Array CodeAction) <- traverse commandForCode errs
-            let actions =
-                    (catMaybes $ map asCommand errs)
-                    <> (commandAction_ <$> (fixAllCommand "Apply all suggestions" $ notImplicitPrelude errs))
-                    <> (organizeImports $ notImplicitPrelude errs)
-                    <> concat codeActions
-                    <> sortImports
-            pure $ filterKind actions
+          codeActions :: Array (Array CodeAction) <- traverse commandForCode
+            errs
+          let
+            actions =
+              (catMaybes $ map asCommand errs)
+                <>
+                  ( commandAction_ <$>
+                      ( fixAllCommand "Apply all suggestions" $
+                          notImplicitPrelude errs
+                      )
+                  )
+                <> (organizeImports $ notImplicitPrelude errs)
+                <> concat codeActions
+                <> sortImports
+          pure $ filterKind actions
     _ -> pure []
   where
   docUri = _.uri $ un TextDocumentIdentifier textDocument
@@ -64,45 +76,77 @@ getActions documents settings state@(ServerState { diagnostics, conn: Just _conn
   filterKind actions =
     case Nullable.toMaybe only of
       Nothing -> actions
-      Just kinds -> Array.filter (\(CodeAction { kind }) -> any (kind `isSubKindOf` _) kinds) actions
+      Just kinds -> Array.filter
+        (\(CodeAction { kind }) -> any (kind `isSubKindOf` _) kinds)
+        actions
 
     where
     -- Sub kind, eg source.organizeImports is a sub-kind of source
-    isSubKindOf (CodeActionKind k1) (CodeActionKind k2) = String.indexOf (Pattern k2) k1 == Just 0
+    isSubKindOf (CodeActionKind k1) (CodeActionKind k2) =
+      String.indexOf (Pattern k2) k1 == Just 0
 
   asCommand :: _ -> Maybe CodeAction
   asCommand error@(RebuildError { position: Just position, errorCode })
     | Just { replacement, range: replaceRange } <- getReplacementRange error
     , intersects (positionToRange position) range = do
-      let replacement' = replace' (regex "\\s*\\n\\s*$" RegexFlags.global) "\n" replacement
-          replacement'' = if errorCode == wildcardInferredType then replace' (regex "\\n\\s*$" RegexFlags.noFlags) "" replacement' else replacement'
-      Just $ commandAction_ $ replaceSuggestion (getTitle errorCode) docUri replacement'' replaceRange
+        let
+          replacement' = replace' (regex "\\s*\\n\\s*$" RegexFlags.global) "\n"
+            replacement
+          replacement'' =
+            if errorCode == wildcardInferredType then replace'
+              (regex "\\n\\s*$" RegexFlags.noFlags)
+              ""
+              replacement'
+            else replacement'
+        Just $ commandAction_ $ replaceSuggestion (getTitle errorCode) docUri
+          replacement''
+          replaceRange
   asCommand _ = Nothing
 
-  getReplacementRange (RebuildError { position: Just position, suggestion: Just (PscSuggestion { replacement, replaceRange }) }) =
+  getReplacementRange
+    ( RebuildError
+        { position: Just position
+        , suggestion: Just (PscSuggestion { replacement, replaceRange })
+        }
+    ) =
     Just $ { replacement, range: range' }
     where
     range' = positionToRange $ fromMaybe position replaceRange
   getReplacementRange _ = Nothing
 
-  notImplicitPrelude = filter (\(RebuildError { errorCode, message }) -> not (errorCode == "ImplicitImport" && String.contains (Pattern "Module Prelude") message))
+  notImplicitPrelude = filter
+    ( \(RebuildError { errorCode, message }) -> not
+        ( errorCode == "ImplicitImport" && String.contains
+            (Pattern "Module Prelude")
+            message
+        )
+    )
 
   -- Sort/format imports via purs ide
-  sortImports = [ commandAction codeActionSourceSortImports (Commands.sortImports docUri) ]
+  sortImports =
+    [ commandAction codeActionSourceSortImports (Commands.sortImports docUri) ]
 
   -- Apply all import suggestions from the compiler
   -- TODO this should probably sort too!
   organizeImports :: _ -> Array CodeAction
   organizeImports errs =
     map (commandAction codeActionSourceOrganizeImports)
-      $ fixAllCommand "Organize Imports" (filter (\(RebuildError { errorCode }) -> isImport errorCode) errs)
+      $ fixAllCommand "Organize Imports"
+          (filter (\(RebuildError { errorCode }) -> isImport errorCode) errs)
 
-  fixAllCommand text rebuildErrors = if length replacements > 0 then [ replaceAllSuggestions text docUri replacements ] else []
+  fixAllCommand text rebuildErrors =
+    if length replacements > 0 then
+      [ replaceAllSuggestions text docUri replacements ]
+    else []
     where
     replacements :: Array { range :: Range, replacement :: String }
-    replacements = removeOverlaps $ sortWith _.range $ nubByEq eq $ mapMaybe getReplacementRange rebuildErrors
+    replacements = removeOverlaps $ sortWith _.range $ nubByEq eq $ mapMaybe
+      getReplacementRange
+      rebuildErrors
 
-  removeOverlaps :: Array { range :: Range, replacement :: String } -> Array { range :: Range, replacement :: String }
+  removeOverlaps ::
+    Array { range :: Range, replacement :: String } ->
+    Array { range :: Range, replacement :: String }
   removeOverlaps = foldl go []
     where
     go [] x = [ x ]
@@ -114,20 +158,26 @@ getActions documents settings state@(ServerState { diagnostics, conn: Just _conn
   commandForCode :: _ -> Aff (Array CodeAction)
   commandForCode err@(RebuildError { position: Just position, errorCode })
     | intersects (positionToRange position) range =
-      case errorCode of
-        "ModuleNotFound" -> pure [ commandAction_  build ]
-        "HoleInferredType" -> case err of
-          RebuildError { pursIde: Just (PursIdeInfo { name, completions }) } ->
-            pure $ singleton $ commandAction_ $ typedHole name docUri (positionToRange position) completions
+        case errorCode of
+          "ModuleNotFound" -> pure [ commandAction_ build ]
+          "HoleInferredType" -> case err of
+            RebuildError { pursIde: Just (PursIdeInfo { name, completions }) } ->
+              pure $ singleton $ commandAction_ $ typedHole name docUri
+                (positionToRange position)
+                completions
+            _ -> pure []
+          x
+            | isUnknownToken x
+            , { startLine, startColumn } <- position ->
+                map commandAction_ <$> fixTypoActions documents settings state
+                  docUri
+                  (startLine - 1)
+                  (startColumn - 1)
           _ -> pure []
-        x
-          | isUnknownToken x
-          , { startLine, startColumn } <- position ->
-            map commandAction_ <$> fixTypoActions documents settings state docUri (startLine - 1) (startColumn - 1)
-        _ -> pure []
   commandForCode _ = pure []
 
-  intersects (Range { start, end }) (Range { start: start', end: end' }) = start <= end' && start' <= end
+  intersects (Range { start, end }) (Range { start: start', end: end' }) =
+    start <= end' && start' <= end
 
 getActions _ _ _ _ = pure []
 
@@ -139,18 +189,20 @@ codeActionLiteralsSupported capabilities =
     >>= (_.codeActionLiteralSupport >>> Nullable.toMaybe)
     # isJust
 
-codeActionToCommand :: Maybe ClientCapabilities -> CodeAction -> Maybe CodeActionResult
+codeActionToCommand ::
+  Maybe ClientCapabilities -> CodeAction -> Maybe CodeActionResult
 codeActionToCommand capabilities action =
   codeActionResult
-    <$> if supportsLiteral then
+    <$>
+      if supportsLiteral then
         Just $ Left action
       else
         convert action
   where
   supportsLiteral = maybe true codeActionLiteralsSupported capabilities
-  convert (CodeAction { command }) | Just c <- Nullable.toMaybe command = Just $ Right c
+  convert (CodeAction { command }) | Just c <- Nullable.toMaybe command = Just $
+    Right c
   convert _ = Nothing
-
 
 commandAction :: CodeActionKind -> Command -> CodeAction
 commandAction kind c@(Command { title }) =
@@ -181,31 +233,45 @@ toNextLine (Range { start, end: Position { line } }) =
     , end: Position { line: line + 1, character: 0 }
     }
 
-onReplaceSuggestion :: DocumentStore -> Settings -> ServerState -> Array Foreign -> Aff Unit
+onReplaceSuggestion ::
+  DocumentStore -> Settings -> ServerState -> Array Foreign -> Aff Unit
 onReplaceSuggestion docs _ (ServerState { conn, clientCapabilities }) args =
   case conn, args of
     Just conn', [ uri', replacement', range' ]
       | Right uri <- runExcept $ readString uri'
       , Right replacement <- runExcept $ readString replacement'
       , Right range <- runExcept $ readRange range' -> do
-        doc <- liftEffect $ getDocument docs (DocumentUri uri)
-        for_ (Nullable.toMaybe doc) \doc -> do
-          version <- liftEffect $ getVersion doc
-          TextEdit { range: range'', newText } <- getReplacementEdit doc { replacement, range }
-          let edit = makeWorkspaceEdit clientCapabilities (DocumentUri uri) version range'' newText
-          -- TODO: Check original & expected text ?
-          void $ applyEdit conn' edit
+          doc <- liftEffect $ getDocument docs (DocumentUri uri)
+          for_ (Nullable.toMaybe doc) \doc -> do
+            version <- liftEffect $ getVersion doc
+            TextEdit { range: range'', newText } <- getReplacementEdit doc
+              { replacement, range }
+            let
+              edit = makeWorkspaceEdit clientCapabilities (DocumentUri uri)
+                version
+                range''
+                newText
+            -- TODO: Check original & expected text ?
+            void $ applyEdit conn' edit
     _, _ -> pure unit
 
 getReplacementEdit :: TextDocument -> Replacement -> Aff TextEdit
 getReplacementEdit doc { replacement, range } = do
-  afterText <- liftEffect $ replace' (regex "\n$" noFlags) "" <$> getTextAtRange doc (afterEnd range)
+  afterText <- liftEffect $ replace' (regex "\n$" noFlags) "" <$> getTextAtRange
+    doc
+    (afterEnd range)
   let
-  -- trim spaces at the end of lines
-    replacementTrimSpaces =  replace' (regex "\\s+\n" RegexFlags.global) "\n" replacement
-  -- remove trailing newline (inserting changes midway through line - eg _ fix)
+    -- trim spaces at the end of lines
+    replacementTrimSpaces = replace' (regex "\\s+\n" RegexFlags.global) "\n"
+      replacement
+    -- remove trailing newline (inserting changes midway through line - eg _ fix)
     removeTrailingNewline = not $ String.null afterText
-    newText = if removeTrailingNewline then replace' (regex "\\s+\n$" RegexFlags.noFlags) "" replacementTrimSpaces else replacementTrimSpaces
+    newText =
+      if removeTrailingNewline then replace'
+        (regex "\\s+\n$" RegexFlags.noFlags)
+        ""
+        replacementTrimSpaces
+      else replacementTrimSpaces
     range' =
       -- deletion (eg import line)
       if newText == "" && afterText == "" then
@@ -214,24 +280,29 @@ getReplacementEdit doc { replacement, range } = do
         range
   pure $ TextEdit { range: range', newText }
 
-onReplaceAllSuggestions :: DocumentStore -> Settings -> ServerState -> Array Foreign -> Aff Unit
+onReplaceAllSuggestions ::
+  DocumentStore -> Settings -> ServerState -> Array Foreign -> Aff Unit
 onReplaceAllSuggestions docs _ (ServerState { conn, clientCapabilities }) args =
   case conn, args of
     Just conn', [ uri', suggestions' ]
       | Right uri <- runExcept $ readString uri'
-      , Right suggestions <- runExcept $ readArray suggestions' >>= traverse readSuggestion -> do
-        doc <- liftEffect $ getDocument docs (DocumentUri uri)
-        for_ (Nullable.toMaybe doc) \doc -> do
-          version <- liftEffect $ getVersion doc
-          edits <- traverse (getReplacementEdit doc) suggestions
-          void
-            $ applyEdit conn'
-            $ workspaceEdit clientCapabilities
-                [ TextDocumentEdit
-                    { textDocument: OptionalVersionedTextDocumentIdentifier { uri: DocumentUri uri, version: Nullable.notNull version }
-                    , edits
-                    }
-                ]
+      , Right suggestions <-
+          runExcept $ readArray suggestions' >>= traverse readSuggestion -> do
+          doc <- liftEffect $ getDocument docs (DocumentUri uri)
+          for_ (Nullable.toMaybe doc) \doc -> do
+            version <- liftEffect $ getVersion doc
+            edits <- traverse (getReplacementEdit doc) suggestions
+            void
+              $ applyEdit conn'
+              $ workspaceEdit clientCapabilities
+                  [ TextDocumentEdit
+                      { textDocument: OptionalVersionedTextDocumentIdentifier
+                          { uri: DocumentUri uri
+                          , version: Nullable.notNull version
+                          }
+                      , edits
+                      }
+                  ]
     _, _ -> pure unit
 
 readSuggestion :: Foreign -> F Replacement

--- a/src/LanguageServer/IdePurescript/CodeLens/ExportManagement.purs
+++ b/src/LanguageServer/IdePurescript/CodeLens/ExportManagement.purs
@@ -27,36 +27,54 @@ import PureScript.CST (RecoveredParserResult(..))
 import PureScript.CST.Traversal (defaultMonoidalVisitor, foldMapModule)
 import PureScript.CST.Types as CST
 
-exportManagementCodeLenses ∷ DocumentStore -> Settings -> ServerState -> DocumentUri -> Aff (Array CodeLensResult)
-exportManagementCodeLenses _documentStore _settings (ServerState { parsedModules }) uri = do
+exportManagementCodeLenses ::
+  DocumentStore ->
+  Settings ->
+  ServerState ->
+  DocumentUri ->
+  Aff (Array CodeLensResult)
+exportManagementCodeLenses
+  _documentStore
+  _settings
+  (ServerState { parsedModules })
+  uri = do
   case _.parsed <$> Map.lookup uri parsedModules of
     Just (ParseSucceeded parsedModule) -> pure $ mkCodeLenses uri parsedModule
-    Just (ParseSucceededWithErrors parsedModule _) -> pure $ mkCodeLenses uri parsedModule
+    Just (ParseSucceededWithErrors parsedModule _) -> pure $ mkCodeLenses uri
+      parsedModule
     _ -> pure []
 
-exportsToArray ∷ ∀ err. CST.Separated (CST.Export err) -> Array (CST.Export err)
+exportsToArray ::
+  forall err. CST.Separated (CST.Export err) -> Array (CST.Export err)
 exportsToArray (CST.Separated { head, tail }) = head : (snd <$> tail)
 
-printExports ∷ Array String -> String
-printExports exports = "\n  ( " <> (intercalate "\n  , " (Array.sort exports)) <> "\n  )\n  "
+printExports :: Array String -> String
+printExports exports = "\n  ( " <> (intercalate "\n  , " (Array.sort exports))
+  <> "\n  )\n  "
 
-printExport ∷ ∀ e. CST.Export e -> Maybe String
+printExport :: forall e. CST.Export e -> Maybe String
 printExport = case _ of
-  CST.ExportOp (CST.Name { name: (CST.Operator name) }) -> Just $ "(" <> name <> ")"
-  CST.ExportType (CST.Name { name: (CST.Proper name) }) members -> Just $ name <> guard (isJust members) "(..)"
-  CST.ExportTypeOp _ (CST.Name { name: (CST.Operator name) }) -> Just $ "type (" <> name <> ")"
-  CST.ExportClass _ (CST.Name { name: (CST.Proper name) }) -> Just $ "class " <> name
-  CST.ExportModule _ (CST.Name { name: CST.ModuleName name }) -> Just $ "module " <> name
+  CST.ExportOp (CST.Name { name: (CST.Operator name) }) ->
+    Just $ "(" <> name <> ")"
+  CST.ExportType (CST.Name { name: (CST.Proper name) }) members ->
+    Just $ name <> guard (isJust members) "(..)"
+  CST.ExportTypeOp _ (CST.Name { name: (CST.Operator name) }) ->
+    Just $ "type (" <> name <> ")"
+  CST.ExportClass _ (CST.Name { name: (CST.Proper name) }) ->
+    Just $ "class " <> name
+  CST.ExportModule _ (CST.Name { name: CST.ModuleName name }) ->
+    Just $ "module " <> name
   CST.ExportValue (CST.Name { name: CST.Ident name }) -> Just $ name
   CST.ExportError _ -> Nothing
 
 data DeclConstructorInfo
   = WithConstructors
   | NoConstructors
+
 derive instance Eq DeclConstructorInfo
 
-newtype DeclNameInfo
-  = DeclNameInfo { range :: LSP.Range, ctors :: DeclConstructorInfo, name :: String }
+newtype DeclNameInfo = DeclNameInfo
+  { range :: LSP.Range, ctors :: DeclConstructorInfo, name :: String }
 
 formatDeclName :: DeclNameInfo -> String
 formatDeclName (DeclNameInfo { name, ctors }) = case ctors of
@@ -66,37 +84,77 @@ formatDeclName (DeclNameInfo { name, ctors }) = case ctors of
 instance Semigroup DeclNameInfo where
   append sr1 _ = sr1
 
-derive instance newtypeSemigroupRange ∷ Newtype DeclNameInfo _
+derive instance newtypeSemigroupRange :: Newtype DeclNameInfo _
 
-getDeclNameInfo ∷ ∀ a. CST.Module a -> SemigroupMap String DeclNameInfo
+getDeclNameInfo :: forall a. CST.Module a -> SemigroupMap String DeclNameInfo
 getDeclNameInfo =
   foldMapModule
     $ defaultMonoidalVisitor
         { onDecl =
-          case _ of
-            CST.DeclSignature (CST.Labeled { label: (CST.Name { token, name: CST.Ident name }) }) -> entry name token.range NoConstructors
-            CST.DeclKindSignature { value: CST.TokLowerName Nothing "class" } (CST.Labeled { label: (CST.Name { token, name: CST.Proper name }) }) -> entry ("class " <> name) token.range NoConstructors
-            CST.DeclKindSignature _ (CST.Labeled { label: (CST.Name { token, name: CST.Proper name }) }) -> entry name token.range NoConstructors
-            CST.DeclValue { name: (CST.Name { token, name: CST.Ident name }) } -> entry name token.range NoConstructors
-            CST.DeclData { name: (CST.Name { token, name: CST.Proper name }) } _ -> entry name token.range WithConstructors
-            CST.DeclNewtype { name: (CST.Name { token, name: CST.Proper name }) } _ _ _ -> entry name token.range WithConstructors
-            CST.DeclType { name: (CST.Name { token, name: CST.Proper name }) } _ _ -> entry name token.range NoConstructors
-            CST.DeclClass { name: (CST.Name { token, name: CST.Proper name }) } _ -> entry ("class " <> name) token.range NoConstructors
-            CST.DeclFixity { operator: CST.FixityValue _ _ (CST.Name { token, name: CST.Operator name }) } -> entry ("(" <> name <> ")") token.range NoConstructors
-            CST.DeclFixity { operator: CST.FixityType _ _ _ (CST.Name { token, name: CST.Operator name }) } -> entry ("type (" <> name <> ")") token.range NoConstructors
-            CST.DeclForeign _ _ (CST.ForeignValue (CST.Labeled { label: (CST.Name { token, name: CST.Ident name }) })) -> entry name token.range NoConstructors
-            CST.DeclForeign _ _ (CST.ForeignData _ (CST.Labeled { label: (CST.Name { token, name: CST.Proper name }) })) -> entry name token.range NoConstructors
-            CST.DeclForeign _ _ (CST.ForeignKind _ (CST.Name { token, name: CST.Proper name })) -> entry name token.range NoConstructors
-            CST.DeclInstanceChain _ -> mempty
-            CST.DeclDerive _ _ _ -> mempty
-            CST.DeclRole _ _ _ _ -> mempty
-            CST.DeclError _ -> mempty
+            case _ of
+              CST.DeclSignature
+                ( CST.Labeled
+                    { label: (CST.Name { token, name: CST.Ident name }) }
+                ) -> entry name token.range NoConstructors
+              CST.DeclKindSignature { value: CST.TokLowerName Nothing "class" }
+                ( CST.Labeled
+                    { label: (CST.Name { token, name: CST.Proper name }) }
+                ) -> entry ("class " <> name) token.range NoConstructors
+              CST.DeclKindSignature _
+                ( CST.Labeled
+                    { label: (CST.Name { token, name: CST.Proper name }) }
+                ) -> entry name token.range NoConstructors
+              CST.DeclValue { name: (CST.Name { token, name: CST.Ident name }) } ->
+                entry name token.range NoConstructors
+              CST.DeclData { name: (CST.Name { token, name: CST.Proper name }) }
+                _ -> entry name token.range WithConstructors
+              CST.DeclNewtype
+                { name: (CST.Name { token, name: CST.Proper name }) }
+                _
+                _
+                _ -> entry name token.range WithConstructors
+              CST.DeclType { name: (CST.Name { token, name: CST.Proper name }) }
+                _
+                _ -> entry name token.range NoConstructors
+              CST.DeclClass
+                { name: (CST.Name { token, name: CST.Proper name }) }
+                _ -> entry ("class " <> name) token.range NoConstructors
+              CST.DeclFixity
+                { operator: CST.FixityValue _ _
+                    (CST.Name { token, name: CST.Operator name })
+                } -> entry ("(" <> name <> ")") token.range NoConstructors
+              CST.DeclFixity
+                { operator: CST.FixityType _ _ _
+                    (CST.Name { token, name: CST.Operator name })
+                } -> entry ("type (" <> name <> ")") token.range NoConstructors
+              CST.DeclForeign _ _
+                ( CST.ForeignValue
+                    ( CST.Labeled
+                        { label: (CST.Name { token, name: CST.Ident name }) }
+                    )
+                ) -> entry name token.range NoConstructors
+              CST.DeclForeign _ _
+                ( CST.ForeignData _
+                    ( CST.Labeled
+                        { label: (CST.Name { token, name: CST.Proper name }) }
+                    )
+                ) -> entry name token.range NoConstructors
+              CST.DeclForeign _ _
+                (CST.ForeignKind _ (CST.Name { token, name: CST.Proper name })) ->
+                entry name token.range NoConstructors
+              CST.DeclInstanceChain _ -> mempty
+              CST.DeclDerive _ _ _ -> mempty
+              CST.DeclRole _ _ _ _ -> mempty
+              CST.DeclError _ -> mempty
         }
   where
-  entry name range ctors = SemigroupMap $ Map.singleton name $ DeclNameInfo { range: sourceRangeToRange range, ctors, name }
+  entry name range ctors = SemigroupMap $ Map.singleton name $ DeclNameInfo
+    { range: sourceRangeToRange range, ctors, name }
 
-mkCodeLenses ∷ ∀ err. DocumentUri -> CST.Module err -> Array CodeLensResult
-mkCodeLenses uri
+mkCodeLenses ::
+  forall err. DocumentUri -> CST.Module err -> Array CodeLensResult
+mkCodeLenses
+  uri
   parsedModule@
     ( CST.Module
         { header:
@@ -111,7 +169,8 @@ mkCodeLenses uri
   let
     start = sourcePosToPosition moduleNameEnd
     end = sourcePosToPosition whereClauseStart
-    exportsRange ∷ LSP.Range
+
+    exportsRange :: LSP.Range
     exportsRange = LSP.Range { start, end }
     noExplicitExports = isNothing exports
     exportArray = case exports of
@@ -126,28 +185,37 @@ mkCodeLenses uri
 
     declToCodeLens info@(DeclNameInfo { name, ctors, range }) = do
       let
-        replace title exps = Array.singleton $ mkCodeLensResult range $ replaceSuggestion title uri (printExports exps) exportsRange
+        replace title exps = Array.singleton $ mkCodeLensResult range $
+          replaceSuggestion title uri (printExports exps) exportsRange
         exported = Array.elem name exportNames
       if noExplicitExports then
         replace ("exported (export only this)") [ name ]
           <> replace ("(export everything else)")
-              (Array.delete name $ Array.fromFoldable $ formatDeclName <$> Map.values decls)
-      else if ctors == WithConstructors && Array.elem (withConstructors name) exportNames then
+              ( Array.delete name $ Array.fromFoldable $ formatDeclName <$>
+                  Map.values decls
+              )
+      else if
+        ctors == WithConstructors && Array.elem (withConstructors name)
+          exportNames then
         let
           otherNames = exportNames # Array.delete (withConstructors name)
         in
-          replace ("exported with constructors (export only type)") (name : otherNames)
+          replace ("exported with constructors (export only type)")
+            (name : otherNames)
             <> replace ("(remove from exports)") otherNames
       else if ctors == WithConstructors && exported then
         let
           otherNames = exportNames # Array.delete name
         in
-          replace ("exported without constructors (export constructors)") (withConstructors name : otherNames)
+          replace ("exported without constructors (export constructors)")
+            (withConstructors name : otherNames)
             <> replace ("(remove from exports)") otherNames
       else if exported then
-        replace ("exported (remove from exports)") (Array.delete name exportNames)
+        replace ("exported (remove from exports)")
+          (Array.delete name exportNames)
       else
-        replace ("private (add to exports)") (exportNames `Array.snoc` formatDeclName info)
+        replace ("private (add to exports)")
+          (exportNames `Array.snoc` formatDeclName info)
 
     moduleLens :: Maybe CodeLensResult
     moduleLens =
@@ -155,20 +223,24 @@ mkCodeLenses uri
         Just
           $ mkCodeLensResult (sourceRangeToRange keyword.range)
           $ replaceSuggestion "implicit module exports - make all explicit" uri
-              (printExports $ Array.fromFoldable $ formatDeclName <$> Map.values decls) exportsRange
+              ( printExports $ Array.fromFoldable $ formatDeclName <$>
+                  Map.values decls
+              )
+              exportsRange
       else
         Nothing
-    privatePublicCodeLenses ∷ Array CodeLensResult
+
+    privatePublicCodeLenses :: Array CodeLensResult
     privatePublicCodeLenses = foldMap declToCodeLens $ Map.values decls
   in
     Array.fromFoldable moduleLens <> privatePublicCodeLenses
   where
-  mkCodeLensResult ∷ LSP.Range -> Command -> CodeLensResult
+  mkCodeLensResult :: LSP.Range -> Command -> CodeLensResult
   mkCodeLensResult codeLensRange replaceCommand = do
     { range: codeLensRange
     , command: Nullable.notNull replaceCommand
     , data: Nullable.null # unsafeToForeign
     }
 
-withConstructors ∷ String -> String
+withConstructors :: String -> String
 withConstructors s = s <> "(..)"

--- a/src/LanguageServer/IdePurescript/CodeLenses.purs
+++ b/src/LanguageServer/IdePurescript/CodeLenses.purs
@@ -1,8 +1,7 @@
 module LanguageServer.IdePurescript.CodeLenses
   ( getCodeLenses
   , supportsRefresh
-  )
-  where
+  ) where
 
 import Prelude
 
@@ -16,23 +15,42 @@ import LanguageServer.IdePurescript.CodeLens.TopLevelDeclarations (topLevelDecla
 import LanguageServer.IdePurescript.Config as Config
 import LanguageServer.IdePurescript.Types (ServerState(..))
 import LanguageServer.Protocol.Handlers (CodeLensParams, CodeLensResult)
-import LanguageServer.Protocol.Types (DocumentStore, Settings, TextDocumentIdentifier(..), ClientCapabilities)
+import LanguageServer.Protocol.Types (ClientCapabilities, DocumentStore, Settings, TextDocumentIdentifier(..))
 
-getCodeLenses ∷ Notify -> Ref ServerState -> DocumentStore -> Settings -> ServerState -> CodeLensParams -> Aff (Array CodeLensResult)
-getCodeLenses _notify _stateRef documentStore settings state { textDocument: TextDocumentIdentifier { uri } } = do
+getCodeLenses ::
+  Notify ->
+  Ref ServerState ->
+  DocumentStore ->
+  Settings ->
+  ServerState ->
+  CodeLensParams ->
+  Aff (Array CodeLensResult)
+getCodeLenses
+  _notify
+  _stateRef
+  documentStore
+  settings
+  state
+  { textDocument: TextDocumentIdentifier { uri } } = do
   let ServerState { runningRebuild } = state
   case runningRebuild of
     Just { fiber } -> do
       joinFiber fiber
     Nothing -> do
       pure unit
-  
+
   let guard b m = if b then m else pure []
 
-  topLevelDeclarations <- topLevelDeclarationLenses documentStore settings state uri # guard (Config.declarationTypeCodeLens settings)
-  exportManagement <- exportManagementCodeLenses documentStore settings state uri # guard (Config.exportsCodeLens settings)
-  pure $ topLevelDeclarations <> exportManagement 
+  topLevelDeclarations <-
+    topLevelDeclarationLenses documentStore settings state uri # guard
+      (Config.declarationTypeCodeLens settings)
+  exportManagement <-
+    exportManagementCodeLenses documentStore settings state uri # guard
+      (Config.exportsCodeLens settings)
+  pure $ topLevelDeclarations <> exportManagement
 
 supportsRefresh :: Maybe ClientCapabilities -> Boolean
-supportsRefresh (Just { workspace }) = fromMaybe false $ toMaybe workspace >>= (_.codeLens >>> toMaybe) >>= (_.refreshSupport >>> toMaybe)
+supportsRefresh (Just { workspace }) = fromMaybe false $ toMaybe workspace
+  >>= (_.codeLens >>> toMaybe)
+  >>= (_.refreshSupport >>> toMaybe)
 supportsRefresh Nothing = false

--- a/src/LanguageServer/IdePurescript/Commands.purs
+++ b/src/LanguageServer/IdePurescript/Commands.purs
@@ -1,6 +1,7 @@
 module LanguageServer.IdePurescript.Commands where
 
 import Prelude
+
 import Data.Array ((:))
 import Data.Maybe (Maybe(..))
 import Data.Nullable (toNullable)
@@ -12,24 +13,33 @@ cmdName :: CommandInfo -> String
 cmdName (CommandInfo _ command) = "purescript." <> command
 
 c :: CommandInfo -> Maybe (Array Foreign) -> Command
-c cmd@(CommandInfo title _) args = Command { title, command: cmdName cmd, arguments: toNullable args }
+c cmd@(CommandInfo title _) args = Command
+  { title, command: cmdName cmd, arguments: toNullable args }
 
-data CommandInfo
-  = CommandInfo String String
+data CommandInfo = CommandInfo String String
 
 caseSplitCmd :: CommandInfo
 caseSplitCmd = CommandInfo "Case split (explicit position)" "caseSplit-explicit"
 
 addClauseCmd :: CommandInfo
-addClauseCmd = CommandInfo "Add clause (explicit position/cmd)" "addClause-explicit"
+addClauseCmd = CommandInfo "Add clause (explicit position/cmd)"
+  "addClause-explicit"
 
 addCompletionImportCmd :: CommandInfo
-addCompletionImportCmd = CommandInfo "Add completion import" "addCompletionImport"
+addCompletionImportCmd = CommandInfo "Add completion import"
+  "addCompletionImport"
 
-addCompletionImport :: String -> Maybe String -> Maybe String -> DocumentUri -> String -> Command
+addCompletionImport ::
+  String -> Maybe String -> Maybe String -> DocumentUri -> String -> Command
 addCompletionImport ident mod qual uri ns =
   c addCompletionImportCmd
-    $ Just [ unsafeToForeign ident, unsafeToForeign $ toNullable mod, unsafeToForeign $ toNullable qual, unsafeToForeign uri, unsafeToForeign ns ]
+    $ Just
+        [ unsafeToForeign ident
+        , unsafeToForeign $ toNullable mod
+        , unsafeToForeign $ toNullable qual
+        , unsafeToForeign uri
+        , unsafeToForeign ns
+        ]
 
 addModuleImportCmd :: CommandInfo
 addModuleImportCmd = CommandInfo "Add module import" "addModuleImport"
@@ -44,13 +54,17 @@ replaceSuggestion :: String -> DocumentUri -> String -> Range -> Command
 replaceSuggestion title uri replacement fixRange =
   c (CommandInfo title "replaceSuggestion")
     $ Just
-    $ [ unsafeToForeign uri, unsafeToForeign replacement, unsafeToForeign fixRange ]
+    $
+      [ unsafeToForeign uri
+      , unsafeToForeign replacement
+      , unsafeToForeign fixRange
+      ]
 
 replaceAllSuggestionsCmd :: CommandInfo
-replaceAllSuggestionsCmd = CommandInfo "Replace all suggestions" "replaceAllSuggestions"
+replaceAllSuggestionsCmd = CommandInfo "Replace all suggestions"
+  "replaceAllSuggestions"
 
-type Replacement
-  = { replacement :: String, range :: Range }
+type Replacement = { replacement :: String, range :: Range }
 
 replaceAllSuggestions :: String -> DocumentUri -> Array Replacement -> Command
 replaceAllSuggestions text uri replacements =
@@ -74,10 +88,14 @@ typedHoleCmd :: CommandInfo
 typedHoleCmd = CommandInfo "Insert typed hole suggestion" "typedHole"
 
 typedHole :: String -> DocumentUri -> Range -> Array TypeInfo -> Command
-typedHole name url range options = c typedHoleCmd (Just $ unsafeToForeign name : unsafeToForeign url : unsafeToForeign range : (unsafeToForeign <$> options))
+typedHole name url range options = c typedHoleCmd
+  ( Just $ unsafeToForeign name : unsafeToForeign url : unsafeToForeign range :
+      (unsafeToForeign <$> options)
+  )
 
 typedHoleExplicitCmd :: CommandInfo
-typedHoleExplicitCmd = CommandInfo "Insert typed hole suggestion" "typedHole-explicit"
+typedHoleExplicitCmd = CommandInfo "Insert typed hole suggestion"
+  "typedHole-explicit"
 
 startPscIdeCmd :: CommandInfo
 startPscIdeCmd = CommandInfo "Start Psc-Ide-Server" "startPscIde"
@@ -89,7 +107,8 @@ restartPscIdeCmd :: CommandInfo
 restartPscIdeCmd = CommandInfo "Restart Psc-Ide-Server" "restartPscIde"
 
 getAvailableModulesCmd :: CommandInfo
-getAvailableModulesCmd = CommandInfo "Get available modules" "getAvailableModules"
+getAvailableModulesCmd = CommandInfo "Get available modules"
+  "getAvailableModules"
 
 searchCmd :: CommandInfo
 searchCmd = CommandInfo "Search identifiers" "search"
@@ -98,10 +117,12 @@ fixTypoCmd :: CommandInfo
 fixTypoCmd = CommandInfo "Fix typo/add import" "fixTypo"
 
 fixTypo :: DocumentUri -> Int -> Int -> Command
-fixTypo uri row char = c fixTypoCmd $ Just $ [ unsafeToForeign uri, unsafeToForeign row, unsafeToForeign char ]
+fixTypo uri row char = c fixTypoCmd $ Just $
+  [ unsafeToForeign uri, unsafeToForeign row, unsafeToForeign char ]
 
 fixTypo' :: String -> DocumentUri -> Int -> Int -> Foreign -> Command
-fixTypo' x uri row char tinfo = c (CommandInfo x "fixTypo") $ Just $ [ unsafeToForeign uri, unsafeToForeign row, unsafeToForeign char, tinfo ]
+fixTypo' x uri row char tinfo = c (CommandInfo x "fixTypo") $ Just $
+  [ unsafeToForeign uri, unsafeToForeign row, unsafeToForeign char, tinfo ]
 
 sortImports :: DocumentUri -> Command
 sortImports uri = c sortImportsCmd $ Just $ [ unsafeToForeign uri ]

--- a/src/LanguageServer/IdePurescript/Config.purs
+++ b/src/LanguageServer/IdePurescript/Config.purs
@@ -46,14 +46,15 @@ module LanguageServer.IdePurescript.Config
   ) where
 
 import Prelude
+
 import Control.Monad.Except (runExcept)
 import Data.Either (either)
-import Foreign (F, Foreign, readArray, readBoolean, readInt, readString)
-import Foreign.Index ((!))
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Traversable (traverse)
-import PscIde.Server (LogLevel(..))
+import Foreign (F, Foreign, readArray, readBoolean, readInt, readString)
+import Foreign.Index ((!))
 import PscIde.Command (CodegenTarget(..))
+import PscIde.Server (LogLevel(..))
 
 getConfigMaybe :: forall a. (Foreign -> F a) -> String -> Foreign -> Maybe a
 getConfigMaybe readValue key settings = do
@@ -77,8 +78,7 @@ getString = getConfig readString
 getInt :: String -> Int -> Foreign -> Int
 getInt = getConfig readInt
 
-type ConfigFn a
-  = Foreign -> a
+type ConfigFn a = Foreign -> a
 
 pursExe :: ConfigFn String
 pursExe = getString "pursExe" "purs"
@@ -120,7 +120,9 @@ autocompleteLimit :: ConfigFn (Maybe Int)
 autocompleteLimit = getConfigMaybe readInt "autocompleteLimit"
 
 importsPreferredModules :: ConfigFn (Array String)
-importsPreferredModules = getConfig (readArray >=> traverse readString) "importsPreferredModules" []
+importsPreferredModules = getConfig (readArray >=> traverse readString)
+  "importsPreferredModules"
+  []
 
 preludeModule :: ConfigFn String
 preludeModule = getString "preludeModule" "Prelude"
@@ -137,7 +139,8 @@ outputDirectory = getConfigMaybe readString "outputDirectory"
 
 -- | Effective output directory (taking account of purs default)
 effectiveOutputDirectory :: ConfigFn String
-effectiveOutputDirectory = fromMaybe "output" <<< ignoreEmpty <<< outputDirectory
+effectiveOutputDirectory = fromMaybe "output" <<< ignoreEmpty <<<
+  outputDirectory
 
 addPscPackageSources :: ConfigFn Boolean
 addPscPackageSources = getBoolean "addPscPackageSources" false
@@ -150,7 +153,6 @@ fullBuildOnSave = getBoolean "fullBuildOnSave" false
 
 fullBuildOnSaveProgress :: ConfigFn Boolean
 fullBuildOnSaveProgress = getBoolean "fullBuildOnSaveProgress" true
-
 
 diagnosticsOnType :: ConfigFn Boolean
 diagnosticsOnType = getBoolean "diagnosticsOnType" false
@@ -182,11 +184,11 @@ logLevel :: ConfigFn (Maybe LogLevel)
 logLevel =
   getString "pscIdelogLevel" ""
     >>> case _ of
-        "all" -> Just All
-        "none" -> Just None
-        "debug" -> Just Debug
-        "perf" -> Just Perf
-        _ -> Nothing
+      "all" -> Just All
+      "none" -> Just None
+      "debug" -> Just Debug
+      "perf" -> Just Perf
+      _ -> Nothing
 
 data Formatter
   = NoFormatter
@@ -198,12 +200,12 @@ formatter :: ConfigFn Formatter
 formatter =
   getString "formatter" ""
     >>> case _ of
-        "purty" -> Purty
-        "purs-tidy" -> PursTidy
-        "tidy" -> PursTidy
-        "pose" -> Pose
-        "" -> NoFormatter
-        _ -> NoFormatter
+      "purty" -> Purty
+      "purs-tidy" -> PursTidy
+      "tidy" -> PursTidy
+      "pose" -> Pose
+      "" -> NoFormatter
+      _ -> NoFormatter
 
 codegenTargets :: ConfigFn (Maybe (Array CodegenTarget))
 codegenTargets =

--- a/src/LanguageServer/IdePurescript/FileTypes.purs
+++ b/src/LanguageServer/IdePurescript/FileTypes.purs
@@ -3,10 +3,10 @@ module LanguageServer.IdePurescript.FileTypes
   , jsUriToMayPsUri
   , uriExtensionIs
   , uriToRelevantFileType
-  )
-  where
+  ) where
 
 import Prelude
+
 import Data.Maybe (Maybe)
 import Data.String as String
 import LanguageServer.Protocol.Types (DocumentUri(..))
@@ -23,7 +23,7 @@ instance Show RelevantFileType where
   show JavaScriptFile = "JavaScriptFile"
   show UnsupportedFile = "UnsupportedFile"
 
-uriToRelevantFileType ∷ DocumentUri → RelevantFileType
+uriToRelevantFileType :: DocumentUri -> RelevantFileType
 uriToRelevantFileType uri = f
   where
   extIs = uriExtensionIs uri
@@ -32,13 +32,13 @@ uriToRelevantFileType uri = f
     | extIs "js" = JavaScriptFile
     | otherwise = UnsupportedFile
 
-uriExtensionIs ∷ DocumentUri → String → Boolean
+uriExtensionIs :: DocumentUri -> String -> Boolean
 uriExtensionIs (DocumentUri uri) ext = ext' == after
   where
   ext' = "." <> ext
   { after } = String.splitAt (String.length uri - String.length ext') uri
 
-jsUriToMayPsUri ∷ DocumentUri → Maybe DocumentUri
+jsUriToMayPsUri :: DocumentUri -> Maybe DocumentUri
 jsUriToMayPsUri (DocumentUri str) =
   (String.stripSuffix (String.Pattern ".js") str)
     <#> (_ <> ".purs")

--- a/src/LanguageServer/IdePurescript/Formatting.purs
+++ b/src/LanguageServer/IdePurescript/Formatting.purs
@@ -1,7 +1,6 @@
 module LanguageServer.IdePurescript.Formatting
   ( getFormattedDocument
-  )
-  where
+  ) where
 
 import Prelude
 
@@ -27,6 +26,7 @@ import LanguageServer.Protocol.DocumentStore (getDocument)
 import LanguageServer.Protocol.Handlers (DocumentFormattingParams)
 import LanguageServer.Protocol.TextDocument (getText)
 import LanguageServer.Protocol.Types (DocumentStore, Position(..), Range(..), Settings, TextDocumentIdentifier(..), TextEdit(..))
+import LanguageServer.Protocol.Uri (uriToFilename)
 import Node.Buffer (Buffer)
 import Node.Buffer as Buffer
 import Node.ChildProcess as CP
@@ -34,17 +34,40 @@ import Node.Encoding (Encoding(..))
 import Node.Encoding as Encoding
 import Node.Stream as S
 
-getFormattedDocument :: Notify -> DocumentStore -> Settings -> ServerState -> DocumentFormattingParams -> Aff (Array TextEdit)
-getFormattedDocument logCb docs settings serverState { textDocument: TextDocumentIdentifier textDocId } = do
+getFormattedDocument ::
+  Notify ->
+  DocumentStore ->
+  Settings ->
+  ServerState ->
+  DocumentFormattingParams ->
+  Aff (Array TextEdit)
+getFormattedDocument
+  logCb
+  docs
+  settings
+  serverState
+  { textDocument: TextDocumentIdentifier textDocId } = do
   case Config.formatter settings of
-    NoFormatter -> pure []
+    NoFormatter -> do
+      liftEffect
+        $ logCb
+            Warning
+            "Trying to format document: no `formatter` value set in settings!"
+      pure []
     formatter -> do
-      maybeDoc <- liftEffect $ Nullable.toMaybe <$> getDocument docs textDocId.uri
+      maybeDoc <- liftEffect $ Nullable.toMaybe <$> getDocument docs
+        textDocId.uri
       case maybeDoc of
         Nothing -> pure []
         Just doc -> do
+          file <- liftEffect $ uriToFilename textDocId.uri
+          liftEffect
+            $ logCb Info
+            $ "Formatting document " <> file <> " with "
+                <> (formatCmd formatter # \(Command cmd _) -> cmd)
           text <- liftEffect $ getText doc
-          newTextEither <- attempt $ format logCb settings serverState formatter text
+          newTextEither <- attempt $ format logCb settings serverState formatter
+            text
           case newTextEither of
             Left err -> liftEffect (logCb Error $ show err) $> []
             Right "" -> pure []
@@ -52,21 +75,25 @@ getFormattedDocument logCb docs settings serverState { textDocument: TextDocumen
 
 purtyCommand :: Command
 purtyCommand = Command "purty" [ "format", "-" ]
+
 pursTidyCommand :: Command
 pursTidyCommand = Command "purs-tidy" [ "format" ]
+
 poseCommand :: Command
 poseCommand = Command "prettier" [ "--parser", "purescript" ]
 
--- TODO for NoFormatter don't provide formatting provider 
+formatCmd :: Formatter -> Command
+formatCmd = case _ of
+  Purty -> purtyCommand
+  PursTidy -> pursTidyCommand
+  Pose -> poseCommand
+  NoFormatter -> Command "echo" [] -- Not possible
+
+-- TODO for NoFormatter don't provide formatting provider
 format :: Notify -> Settings -> ServerState -> Formatter -> String -> Aff String
 format _logCb settings state formatter text = do
   let
-    command = case formatter of
-      Purty -> purtyCommand
-      PursTidy -> pursTidyCommand
-      Pose -> poseCommand
-      NoFormatter -> Command "echo" [] -- Not possible
-    Command _cmd _ = command
+    command@(Command _cmd _) = formatCmd formatter
   case state of
     ServerState { root: Just directory } -> do
       makeAff
@@ -74,24 +101,33 @@ format _logCb settings state formatter text = do
             let
               succ = cb <<< Right
               err = cb <<< Left
-            cp <- spawn { command, directory, useNpmDir: Config.addNpmPath settings }
+            cp <- spawn
+              { command
+              , directory
+              , useNpmDir: Config.addNpmPath settings
+              }
             CP.onError cp (err <<< CP.toStandardError)
             result <- Ref.new []
-            
             let
               res :: Buffer -> Effect Unit
               res s = Ref.modify_ (_ `Array.snoc` s) result
-            catchException err $ S.onDataString (CP.stderr cp) Encoding.UTF8 $ err <<< error
+            catchException err $ S.onDataString (CP.stderr cp) Encoding.UTF8 $
+              err <<< error
             catchException err $ S.onData (CP.stdout cp) res
             CP.onClose cp \exit -> case exit of
               CP.Normally n
-                | n == 0 || n == 1 -> 
-                  Ref.read result >>= Buffer.concat >>= Buffer.toString Encoding.UTF8 >>= succ
+                | n == 0 || n == 1 ->
+                    Ref.read result >>= Buffer.concat
+                      >>= Buffer.toString Encoding.UTF8
+                      >>= succ
               _ -> do
                 let Command cmd _ = command
                 err $ error $ cmd <> " process exited abnormally"
             when (not $ Foreign.isUndefined $ unsafeToForeign $ CP.pid cp) do
-              catchException err $ void $ S.writeString (CP.stdin cp) UTF8 text (const $ pure unit)
+              catchException err $ void $ S.writeString (CP.stdin cp) UTF8 text
+                ( const
+                    $ pure unit
+                )
               catchException err $ S.end (CP.stdin cp) (const $ pure unit)
             pure mempty
     _ -> pure ""

--- a/src/LanguageServer/IdePurescript/Main.js
+++ b/src/LanguageServer/IdePurescript/Main.js
@@ -1,4 +1,4 @@
-export function version () {
+export function version() {
   try {
     return require("./package.json").version;
   } catch (e) {

--- a/src/LanguageServer/IdePurescript/Main.purs
+++ b/src/LanguageServer/IdePurescript/Main.purs
@@ -248,7 +248,7 @@ buildWarningDialog config conn state notify msg = do
 -- | Tries to start IDE server at workspace root
 mkStartPscIdeServer :: Ref Foreign -> Connection -> Ref ServerState -> Notify -> Aff Unit
 mkStartPscIdeServer config conn state notify = do
-  liftEffect $ notify Info "Starting IDE server"
+  liftEffect $ notify Info "Going to start purs IDE server"
   progressReporter <- createWorkDoneProgress conn
   liftEffect $ workBegin progressReporter { title: "Starting PureScript IDE server" }
   rootPath <- liftEffect $ Build.getWorkspaceRoot state
@@ -339,7 +339,7 @@ autoStartPcsIdeServer config conn state notify = do
   when (Config.autoStartPscIde c)
     $ do
         startPscIdeServer
-        hasPackageFile <- liftEffect $ 
+        hasPackageFile <- liftEffect $
           or
             <$> traverse (FSSync.exists <=< resolvePath)
                 [ "bower.json", "psc-package.json", "spago.dhall", "spago.yaml", "flake.nix", "shell.nix" ]

--- a/src/LanguageServer/IdePurescript/Main.purs
+++ b/src/LanguageServer/IdePurescript/Main.purs
@@ -109,16 +109,18 @@ modifyState_ state mod =
   void $ modifyState state mod
 
 readState ::
-  ∀ a.
-  Ref ServerState -> (ServerStateRec -> a) -> Effect a
+  forall a.
+  Ref ServerState ->
+  (ServerStateRec -> a) ->
+  Effect a
 readState state get =
   get <$> un ServerState <$> Ref.read state
 
-type CmdLineArguments
-  = { config :: Maybe String
-    , filename :: Maybe String
-    , version :: Boolean
-    }
+type CmdLineArguments =
+  { config :: Maybe String
+  , filename :: Maybe String
+  , version :: Boolean
+  }
 
 -- | Parses command line arguments  passed to process.argv
 parseArgs :: Array String -> Maybe CmdLineArguments
@@ -146,8 +148,8 @@ updateModules ::
 updateModules state documents uri =
   liftEffect (Ref.read state)
     >>= case _ of
-        ServerState { port: Just port, modulesFile }
-          | modulesFile /= Just uri -> do
+      ServerState { port: Just port, modulesFile }
+        | modulesFile /= Just uri -> do
             maybeDoc <- liftEffect $ getDocument documents uri
             for (Nullable.toMaybe maybeDoc) \doc -> do
               text <- liftEffect $ getText doc
@@ -156,7 +158,7 @@ updateModules state documents uri =
               liftEffect
                 $ modifyState state
                     _ { modules = modules, modulesFile = Just uri }
-        _ -> pure Nothing
+      _ -> pure Nothing
 
 mkRunHandler ::
   Ref Foreign ->
@@ -172,12 +174,13 @@ mkRunHandler config state documents _handlerName maybeGetDocUri f b =
   Promise.fromAff do
     -- Should not allow any js files through
     case maybeGetDocUri b of
-      Just uri | FileTypes.JavaScriptFile <- FileTypes.uriToRelevantFileType uri ->
-        -- TODO :(
-        -- Returning null here rather than throwing an exception which will show up in output. Likely null is actually
-        -- valid return from all handlers and types can be adjusted; alternatively perhaps these handlers can only be registered
-        -- for .purs while getting changes for others.
-        pure $ unsafeCoerce null
+      Just uri
+        | FileTypes.JavaScriptFile <- FileTypes.uriToRelevantFileType uri ->
+            -- TODO :(
+            -- Returning null here rather than throwing an exception which will show up in output. Likely null is actually
+            -- valid return from all handlers and types can be adjusted; alternatively perhaps these handlers can only be registered
+            -- for .purs while getting changes for others.
+            pure $ unsafeCoerce null
       maybeUri -> do
         c <- liftEffect $ Ref.read config
         ms <- maybe (pure Nothing) (updateModules state documents) maybeUri
@@ -187,13 +190,15 @@ mkRunHandler config state documents _handlerName maybeGetDocUri f b =
 -- | Extracts document uri value
 getTextDocUri ::
   forall r.
-  { textDocument :: TextDocumentIdentifier | r } -> Maybe DocumentUri
-getTextDocUri = (Just <<< _.uri <<< un TextDocumentIdentifier <<< _.textDocument)
+  { textDocument :: TextDocumentIdentifier | r } ->
+  Maybe DocumentUri
+getTextDocUri =
+  (Just <<< _.uri <<< un TextDocumentIdentifier <<< _.textDocument)
 
 -- | This mutes buggy warning coming from purs-ide, just to keep the output clean.
 -- | The issue: https://github.com/purescript/purescript/issues/3377
 muteReexportsWarn ::
-  (Connection → String → Effect Unit) -> Connection -> String -> Effect Unit
+  (Connection -> String -> Effect Unit) -> Connection -> String -> Effect Unit
 muteReexportsWarn logFn con str =
   if str # contains (Pattern "Failed to resolve reexports for Type.") then
     pure unit
@@ -205,17 +210,18 @@ mkNotify ::
 mkNotify logFile state l s = do
   readState state _.conn
     >>= maybe (pure unit)
-        ( flip
-            case l of
-              Success -> log
-              Info -> muteReexportsWarn info
-              Warning -> warn
-              Error -> error
-            s
-        )
+      ( flip
+          case l of
+            Success -> log
+            Info -> muteReexportsWarn info
+            Warning -> warn
+            Error -> error
+          s
+      )
   case logFile of
     Just filename ->
-      FSSync.appendTextFile Encoding.UTF8 filename ("[" <> show l <> "] " <> s <> "\n")
+      FSSync.appendTextFile Encoding.UTF8 filename
+        ("[" <> show l <> "] " <> s <> "\n")
     Nothing -> pure unit
 
 -- | Stops IDE server
@@ -225,19 +231,31 @@ mkStopPscIdeServer state notify = do
   quit
   liftEffect do
     Ref.modify_
-      (over ServerState $ _ { port = Nothing, deactivate = pure unit, modules = initialModulesState, runningRebuild = Nothing })
+      ( over ServerState $ _
+          { port = Nothing
+          , deactivate = pure unit
+          , modules = initialModulesState
+          , runningRebuild = Nothing
+          }
+      )
       state
     notify Success "Stopped IDE server"
 
 -- | Reads workspace root from state
 buildWarningDialog ::
-  Ref Foreign -> Connection -> Ref ServerState -> (ErrorLevel -> String -> Effect Unit) -> String -> Aff Unit
+  Ref Foreign ->
+  Connection ->
+  Ref ServerState ->
+  (ErrorLevel -> String -> Effect Unit) ->
+  String ->
+  Aff Unit
 buildWarningDialog config conn state notify msg = do
   let buildOption = "Build project"
   action <-
     showWarningWithActions conn
       ( msg
-          <> ". \n\nEnsure project is built with the same purs version as the IDE server is using"
+          <>
+            ". \n\nEnsure project is built with the same purs version as the IDE server is using"
       )
       [ buildOption ]
   when (action == Just buildOption) do
@@ -246,11 +264,13 @@ buildWarningDialog config conn state notify msg = do
     liftEffect $ Build.requestFullBuild config conn state notify
 
 -- | Tries to start IDE server at workspace root
-mkStartPscIdeServer :: Ref Foreign -> Connection -> Ref ServerState -> Notify -> Aff Unit
+mkStartPscIdeServer ::
+  Ref Foreign -> Connection -> Ref ServerState -> Notify -> Aff Unit
 mkStartPscIdeServer config conn state notify = do
   liftEffect $ notify Info "Going to start purs IDE server"
   progressReporter <- createWorkDoneProgress conn
-  liftEffect $ workBegin progressReporter { title: "Starting PureScript IDE server" }
+  liftEffect $ workBegin progressReporter
+    { title: "Starting PureScript IDE server" }
   rootPath <- liftEffect $ Build.getWorkspaceRoot state
   settings <- liftEffect $ Ref.read config
   startRes <- Server.startServer' settings rootPath notify notify
@@ -258,19 +278,21 @@ mkStartPscIdeServer config conn state notify = do
     { port: Just port, quit } -> do
       Server.loadAll port
         >>= case _ of
-            Left msg
-              | String.contains (Pattern "Version mismatch for the externs") msg -> do
-                liftEffect $ info conn $ "Error loading modules: " <> msg
-                buildWarningDialog config conn state notify
-                  $ msg
-                  <> ". Ensure project is built with the same purs version as the IDE server is using"
+          Left msg
+            | String.contains (Pattern "Version mismatch for the externs") msg ->
+                do
+                  liftEffect $ info conn $ "Error loading modules: " <> msg
+                  buildWarningDialog config conn state notify
+                    $ msg
+                        <>
+                          ". Ensure project is built with the same purs version as the IDE server is using"
 
-            Left msg ->
-              liftEffect
-                $ notify Info
-                $ "Non-fatal error loading modules: "
-                <> msg
-            _ -> pure unit
+          Left msg ->
+            liftEffect
+              $ notify Info
+              $ "Non-fatal error loading modules: "
+                  <> msg
+          _ -> pure unit
       liftEffect do
         Ref.modify_
           (over ServerState $ _ { port = Just port, deactivate = quit })
@@ -285,25 +307,27 @@ mkStartPscIdeServer config conn state notify = do
 connect :: Ref ServerState -> Effect Connection
 connect state =
   initConnection
-    commands \({ params: InitParams { rootPath, rootUri, capabilities }, conn }) -> do
-    Process.argv >>= \args -> log conn $ "Starting with args: " <> show args
-    root <- case toMaybe rootUri, toMaybe rootPath of
-      Just uri, _ -> Just <$> uriToFilename uri
-      _, Just path -> pure $ Just path
-      Nothing, Nothing -> pure Nothing
-    workingRoot <- maybe Process.cwd pure root
-    modifyState_ state
-      _
-        { root = Just workingRoot
-        , clientCapabilities = Just capabilities
-        }
-    ( \(Tuple dir root') ->
-        log conn ("Starting with cwd: " <> dir <> " and using root path: " <> root')
-    )
-      =<< Tuple
-      <$> Process.cwd
-      <*> pure workingRoot
-    Ref.modify_ (over ServerState $ _ { conn = Just conn }) state
+    commands
+    \({ params: InitParams { rootPath, rootUri, capabilities }, conn }) -> do
+      Process.argv >>= \args -> log conn $ "Starting with args: " <> show args
+      root <- case toMaybe rootUri, toMaybe rootPath of
+        Just uri, _ -> Just <$> uriToFilename uri
+        _, Just path -> pure $ Just path
+        Nothing, Nothing -> pure Nothing
+      workingRoot <- maybe Process.cwd pure root
+      modifyState_ state
+        _
+          { root = Just workingRoot
+          , clientCapabilities = Just capabilities
+          }
+      ( \(Tuple dir root') ->
+          log conn
+            ("Starting with cwd: " <> dir <> " and using root path: " <> root')
+      )
+        =<< Tuple
+          <$> Process.cwd
+          <*> pure workingRoot
+      Ref.modify_ (over ServerState $ _ { conn = Just conn }) state
 
 -- | Deletes output from previous build
 cleanProject :: Connection -> Foreign -> Aff Unit
@@ -312,13 +336,13 @@ cleanProject conn config = do
   liftEffect $ info conn "Started cleaning compiled output"
   clean config
     >>= case _ of
-        Left err ->
-          liftEffect do
-            error conn err
-            showError conn err
-        Right msg ->
-          liftEffect do
-            log conn $ msg
+      Left err ->
+        liftEffect do
+          error conn err
+          showError conn err
+      Right msg ->
+        liftEffect do
+          log conn $ msg
   liftEffect $ info conn "Finished cleaning compiled output"
   liftEffect $ sendCleanEnd conn
 
@@ -342,72 +366,105 @@ autoStartPcsIdeServer config conn state notify = do
         hasPackageFile <- liftEffect $
           or
             <$> traverse (FSSync.exists <=< resolvePath)
-                [ "bower.json", "psc-package.json", "spago.dhall", "spago.yaml", "flake.nix", "shell.nix" ]
+              [ "bower.json"
+              , "psc-package.json"
+              , "spago.dhall"
+              , "spago.yaml"
+              , "flake.nix"
+              , "shell.nix"
+              ]
         envIdeSources <- Server.getEnvPursIdeSources
         when (not hasPackageFile && isNothing envIdeSources) do
           liftEffect
             $ showError conn
                 ( "It doesn't look like the workspace root is a PureScript project"
-                    <> "(has bower.json/psc-package.json/spago.dhall/flake.nix/shell.nix)."
-                    <> "The PureScript project should be opened as a root workspace folder."
+                    <>
+                      "(has bower.json/psc-package.json/spago.dhall/flake.nix/shell.nix)."
+                    <>
+                      "The PureScript project should be opened as a root workspace folder."
                 )
         outputDir <- liftEffect $ Build.getOutputDir config state
         exists <- liftEffect $ FSSync.exists outputDir
         unless exists
           $ liftEffect
           $ launchAff do
-              let message = "Output directory does not exist at '" <> outputDir <> "'"
+              let
+                message = "Output directory does not exist at '" <> outputDir <>
+                  "'"
               liftEffect $ info conn message
               buildWarningDialog config conn state notify
                 $ message
-                <> ". Ensure project is built, or check configuration of output directory and build command."
+                    <>
+                      ". Ensure project is built, or check configuration of output directory and build command."
 
 -- | Puts event handlers
 handleEvents ::
   Ref Foreign ->
   Connection ->
   Ref ServerState ->
-  DocumentStore -> Notify -> Effect Unit
+  DocumentStore ->
+  Notify ->
+  Effect Unit
 handleEvents config conn state documents notify = do
   let
     runHandler = mkRunHandler config state documents
     stopPscIdeServer = mkStopPscIdeServer state notify
   onCompletion conn
     $ runHandler
-        "onCompletion" getTextDocUri (getCompletions notify documents)
+        "onCompletion"
+        getTextDocUri
+        (getCompletions notify documents)
   onDefinition conn
     $ runHandler
-        "onDefinition" getTextDocUri (getDefinition notify documents)
+        "onDefinition"
+        getTextDocUri
+        (getDefinition notify documents)
   onDocumentSymbol conn
     $ runHandler
-        "onDocumentSymbol" getTextDocUri getDocumentSymbols
+        "onDocumentSymbol"
+        getTextDocUri
+        getDocumentSymbols
   onWorkspaceSymbol conn
     $ runHandler
-        "onWorkspaceSymbol" (const Nothing) getWorkspaceSymbols
+        "onWorkspaceSymbol"
+        (const Nothing)
+        getWorkspaceSymbols
   onFoldingRanges conn
     $ runHandler
-        "onFoldingRanges" getTextDocUri (getFoldingRanges notify documents)
+        "onFoldingRanges"
+        getTextDocUri
+        (getFoldingRanges notify documents)
   onDocumentFormatting conn
     $ runHandler
-        "onDocumentFormatting" getTextDocUri (getFormattedDocument notify documents)
+        "onDocumentFormatting"
+        getTextDocUri
+        (getFormattedDocument notify documents)
   onReferences conn
     $ runHandler
-        "onReferences" getTextDocUri (getReferences documents)
+        "onReferences"
+        getTextDocUri
+        (getReferences documents)
   onHover conn
     $ runHandler
-        "onHover" getTextDocUri (getTooltips documents)
+        "onHover"
+        getTextDocUri
+        (getTooltips documents)
   onCodeAction conn
     $ runHandler
-        "onCodeAction" getTextDocUri (getActions documents)
+        "onCodeAction"
+        getTextDocUri
+        (getActions documents)
   onCodeLens conn
     $ runHandler
-        "onCodeLens" getTextDocUri (getCodeLenses notify state documents)
+        "onCodeLens"
+        getTextDocUri
+        (getCodeLenses notify state documents)
   onShutdown conn $ Promise.fromAff stopPscIdeServer
   --
   onDidChangeWatchedFiles
     conn
     $ launchAff_
-    <<< handleDidChangeWatchedFiles config conn state documents
+        <<< handleDidChangeWatchedFiles config conn state documents
   --
   onDidChangeContent documents
     $ \{ document } -> do
@@ -425,7 +482,9 @@ handleConfig ::
   Ref Foreign ->
   Connection ->
   Ref ServerState ->
-  Maybe Foreign -> Notify -> Aff Unit
+  Maybe Foreign ->
+  Notify ->
+  Aff Unit
 handleConfig config conn state cmdLineConfig notify = do
   let launchAff = void <<< launchAffLog notify
   gotConfig :: AVar Unit <- AVar.empty
@@ -437,8 +496,8 @@ handleConfig config conn state cmdLineConfig notify = do
         Ref.write newConfig config
       AVar.tryPut unit gotConfig
         >>= case _ of
-            true -> pure unit
-            false -> liftEffect $ log conn "Not starting server, already started"
+          true -> pure unit
+          false -> liftEffect $ log conn "Not starting server, already started"
   liftEffect
     $ onDidChangeConfiguration conn
     $ \{ settings } ->
@@ -478,7 +537,8 @@ handleCommands ::
   Effect Unit
 handleCommands config conn state documents notify = do
   let
-    onBuild _ _ _ _ = liftEffect $ Build.requestFullBuild config conn state notify
+    onBuild _ _ _ _ = liftEffect $ Build.requestFullBuild config conn state
+      notify
     onClean _ c _ _ = cleanProject conn c
     stopPscIdeServer = mkStopPscIdeServer state notify
     startPscIdeServer = mkStartPscIdeServer config conn state notify
@@ -491,34 +551,34 @@ handleCommands config conn state documents notify = do
     voidHandler h d c s a =
       try (h d c s a)
         >>= case _ of
-            Left err -> do
-              liftEffect $ notify Error $ show err
-              pure noResult
-            Right _ -> pure noResult
+          Left err -> do
+            liftEffect $ notify Error $ show err
+            pure noResult
+          Right _ -> pure noResult
     simpleHandler h _ _ _ _ = h $> noResult
   let
     handlers :: Object (CommandHandler Foreign)
     handlers =
       Object.fromFoldable
         $ first cmdName
-        <$>
-          [ caseSplitCmd /\ voidHandler caseSplit
-          , addClauseCmd /\ voidHandler addClause
-          , replaceSuggestionCmd /\ voidHandler onReplaceSuggestion
-          , replaceAllSuggestionsCmd /\ voidHandler onReplaceAllSuggestions
-          , buildCmd /\ voidHandler onBuild
-          , cleanCmd /\ voidHandler onClean
-          , addCompletionImportCmd /\ addCompletionImport notify
-          , addModuleImportCmd /\ voidHandler (addModuleImport' notify)
-          , sortImportsCmd /\ reformatImports notify
-          , startPscIdeCmd /\ simpleHandler startPscIdeServer
-          , stopPscIdeCmd /\ simpleHandler stopPscIdeServer
-          , restartPscIdeCmd /\ simpleHandler restartPscIdeServer
-          , getAvailableModulesCmd /\ getAllModules notify
-          , searchCmd /\ search
-          , fixTypoCmd /\ fixTypo notify
-          , typedHoleExplicitCmd /\ voidHandler (fillTypedHole notify)
-          ]
+            <$>
+              [ caseSplitCmd /\ voidHandler caseSplit
+              , addClauseCmd /\ voidHandler addClause
+              , replaceSuggestionCmd /\ voidHandler onReplaceSuggestion
+              , replaceAllSuggestionsCmd /\ voidHandler onReplaceAllSuggestions
+              , buildCmd /\ voidHandler onBuild
+              , cleanCmd /\ voidHandler onClean
+              , addCompletionImportCmd /\ addCompletionImport notify
+              , addModuleImportCmd /\ voidHandler (addModuleImport' notify)
+              , sortImportsCmd /\ reformatImports notify
+              , startPscIdeCmd /\ simpleHandler startPscIdeServer
+              , stopPscIdeCmd /\ simpleHandler stopPscIdeServer
+              , restartPscIdeCmd /\ simpleHandler restartPscIdeServer
+              , getAvailableModulesCmd /\ getAllModules notify
+              , searchCmd /\ search
+              , fixTypoCmd /\ fixTypo notify
+              , typedHoleExplicitCmd /\ voidHandler (fillTypedHole notify)
+              ]
   onExecuteCommand conn
     $ \{ command, arguments } ->
         Promise.fromAff do
@@ -545,7 +605,9 @@ main = do
       v <- version
       Console.log v
     Just args -> do
-      maybe (pure unit) (flip (FSSync.writeTextFile Encoding.UTF8) "Starting logging...\n") args.filename
+      maybe (pure unit)
+        (flip (FSSync.writeTextFile Encoding.UTF8) "Starting logging...\n")
+        args.filename
       let
         config' = case args.config of
           Just c -> either (const Nothing) Just $ runExcept $ parseJSON c
@@ -565,6 +627,7 @@ main' { filename: logFile, config: cmdLineConfig } = do
   let notify = mkNotify logFile state
   handleEvents config conn state documents notify
   handleCommands config conn state documents notify
-  void $ launchAffLog notify $ handleConfig config conn state cmdLineConfig notify
+  void $ launchAffLog notify $ handleConfig config conn state cmdLineConfig
+    notify
   plsVersion <- version
   log conn $ "PureScript Language Server started (" <> plsVersion <> ")"

--- a/src/LanguageServer/IdePurescript/Search.purs
+++ b/src/LanguageServer/IdePurescript/Search.purs
@@ -2,10 +2,10 @@ module LanguageServer.IdePurescript.Search
   ( SearchResult
   , decodeSearchResult
   , search
-  )
-  where
+  ) where
 
 import Prelude
+
 import Control.Monad.Except (Except, runExcept)
 import Data.Either (Either(..))
 import Data.List.Types (NonEmptyList)
@@ -22,8 +22,8 @@ import PscIde as P
 import PscIde.Command (TypeInfo(..))
 import PscIde.Command as C
 
-newtype SearchResult
-  = SearchResult { identifier :: String, typ :: String, mod :: String }
+newtype SearchResult = SearchResult
+  { identifier :: String, typ :: String, mod :: String }
 
 encodeSearchResult :: SearchResult -> Foreign
 encodeSearchResult = unsafeToForeign
@@ -35,14 +35,19 @@ decodeSearchResult obj = do
   mod <- obj ! "mod" >>= readString
   pure $ SearchResult { identifier, typ, mod }
 
-search :: DocumentStore -> Settings -> ServerState -> Array Foreign -> Aff Foreign
+search ::
+  DocumentStore -> Settings -> ServerState -> Array Foreign -> Aff Foreign
 search _ _ state args = case state, runExcept $ traverse readString args of
   ServerState { port: Just port, modules }, Right [ text ] -> do
     loadedModules <- getLoadedModules port
     let getQualifiedModule = (flip getQualModule) modules
-    results <- getCompletion' (Just $ C.Flex text) [] port modules.main Nothing loadedModules getQualifiedModule P.defaultCompletionOptions
+    results <- getCompletion' (Just $ C.Flex text) [] port modules.main Nothing
+      loadedModules
+      getQualifiedModule
+      P.defaultCompletionOptions
     pure $ unsafeToForeign $ toResult <$> results
   _, _ -> pure $ unsafeToForeign []
 
   where
-  toResult (TypeInfo { type', identifier, module' }) = encodeSearchResult $ SearchResult { typ: type', identifier, mod: module' }
+  toResult (TypeInfo { type', identifier, module' }) = encodeSearchResult $
+    SearchResult { typ: type', identifier, mod: module' }

--- a/src/LanguageServer/IdePurescript/SuggestionRank.purs
+++ b/src/LanguageServer/IdePurescript/SuggestionRank.purs
@@ -7,6 +7,7 @@ module LanguageServer.IdePurescript.SuggestionRank
   ) where
 
 import Prelude
+
 import Data.Char as Char
 import Data.Enum (class Enum)
 import Data.Functor.Contravariant (class Contravariant)
@@ -15,8 +16,7 @@ import Data.Newtype (class Newtype, unwrap)
 import Data.Ordering (invert)
 import Data.String as CodePoint
 
-newtype SuggestionRank
-  = SuggestionRank Int
+newtype SuggestionRank = SuggestionRank Int
 
 derive instance eqSuggestionRank :: Eq SuggestionRank
 
@@ -45,10 +45,10 @@ fromInt :: Int -> SuggestionRank
 fromInt = SuggestionRank <<< clamp 0 25
 
 toString :: SuggestionRank -> String
-toString (SuggestionRank n) = CodePoint.singleton $ CodePoint.codePointFromChar $ fromMaybe ' ' (Char.fromCharCode (65 + n))
+toString (SuggestionRank n) = CodePoint.singleton $ CodePoint.codePointFromChar
+  $ fromMaybe ' ' (Char.fromCharCode (65 + n))
 
-newtype Ranking a
-  = Ranking (a -> SuggestionRank)
+newtype Ranking a = Ranking (a -> SuggestionRank)
 
 derive instance newtypeRanking :: Newtype (Ranking a) _
 

--- a/src/LanguageServer/IdePurescript/Symbols.purs
+++ b/src/LanguageServer/IdePurescript/Symbols.purs
@@ -7,6 +7,7 @@ module LanguageServer.IdePurescript.Symbols
   ) where
 
 import Prelude
+
 import Control.Alt ((<|>))
 import Control.Apply (lift2)
 import Data.Array (catMaybes, foldr, singleton, (:))
@@ -35,7 +36,7 @@ import IdePurescript.Tokens (identifierAtPoint)
 import LanguageServer.IdePurescript.Types (ServerState(..))
 import LanguageServer.IdePurescript.Util.CST (sourceRangeToRange)
 import LanguageServer.Protocol.DocumentStore (getDocument)
-import LanguageServer.Protocol.Handlers (TextDocumentPositionParams, WorkspaceSymbolParams, DocumentSymbolParams)
+import LanguageServer.Protocol.Handlers (DocumentSymbolParams, TextDocumentPositionParams, WorkspaceSymbolParams)
 import LanguageServer.Protocol.TextDocument (getTextAtRange)
 import LanguageServer.Protocol.Types (ClientCapabilities, DocumentStore, DocumentUri, GotoDefinitionResult, Location(..), LocationLink(..), Position(..), Range(..), Settings, SymbolInformation(..), SymbolKind(..), TextDocumentIdentifier(..), gotoDefinitionResult, symbolKindToInt)
 import LanguageServer.Protocol.Uri (filenameToUri)
@@ -49,10 +50,12 @@ import PureScript.CST.Types (Declaration(..), DoStatement(..), Expr(..), LetBind
 import PureScript.CST.Types as CST
 
 convPosition :: Command.Position -> Position
-convPosition { line, column } = Position { line: line - 1, character: column - 1 }
+convPosition { line, column } = Position
+  { line: line - 1, character: column - 1 }
 
 convTypePosition :: Command.TypePosition -> Range
-convTypePosition (Command.TypePosition { start, end }) = Range { start: convPosition start, end: convPosition end }
+convTypePosition (Command.TypePosition { start, end }) = Range
+  { start: convPosition start, end: convPosition end }
 
 getDefinition ::
   Notify ->
@@ -61,32 +64,57 @@ getDefinition ::
   ServerState ->
   TextDocumentPositionParams ->
   Aff (Nullable GotoDefinitionResult)
-getDefinition _notify docs _ state@(ServerState { clientCapabilities: Just clientCapabilities, parsedModules }) ({ textDocument, position }) =
+getDefinition
+  _notify
+  docs
+  _
+  state@
+    (ServerState { clientCapabilities: Just clientCapabilities, parsedModules })
+  ({ textDocument, position }) =
   toNullable
     <$> do
-        let uri = _.uri $ un TextDocumentIdentifier textDocument
-        maybeDoc <- liftEffect $ getDocument docs uri
-        case Nullable.toMaybe maybeDoc of
-          Nothing -> pure Nothing
-          Just doc -> do
-            text <- liftEffect $ getTextAtRange doc (mkLineRange position)
-            let { port, modules, root } = un ServerState $ state
-            case port, root, identifierAtPoint text (_.character $ un Position position) of
-              Just port', Just root', Just identRes@{ range, qualifier, word } -> do
+      let uri = _.uri $ un TextDocumentIdentifier textDocument
+      maybeDoc <- liftEffect $ getDocument docs uri
+      case Nullable.toMaybe maybeDoc of
+        Nothing -> pure Nothing
+        Just doc -> do
+          text <- liftEffect $ getTextAtRange doc (mkLineRange position)
+          let { port, modules, root } = un ServerState $ state
+          case
+            port,
+            root,
+            identifierAtPoint text (_.character $ un Position position)
+            of
+            Just port', Just root', Just identRes@{ range, qualifier, word } ->
+              do
                 localDefn uri word
                   >>= case _ of
-                      Just res | isNothing qualifier -> pure $ Just res
-                      _ -> do
-                        info <- lift2 (<|>) (moduleInfo port' identRes range) (typeInfo port' modules identRes)
-                        for info \{ typePos: Command.TypePosition { name, start }, originRange } -> do
-                          defnUri <- liftEffect $ filenameToUri =<< resolve [ root' ] name
-                          let startRange = Range { start: convPosition start, end: convPosition start }
+                    Just res | isNothing qualifier -> pure $ Just res
+                    _ -> do
+                      info <- lift2 (<|>) (moduleInfo port' identRes range)
+                        (typeInfo port' modules identRes)
+                      for info
+                        \{ typePos: Command.TypePosition { name, start }
+                         , originRange
+                         } -> do
+                          defnUri <- liftEffect $ filenameToUri =<< resolve
+                            [ root' ]
+                            name
+                          let
+                            startRange = Range
+                              { start: convPosition start
+                              , end: convPosition start
+                              }
                           pure $ mkResult defnUri originRange startRange
-              _, _, _ -> pure Nothing
+            _, _, _ -> pure Nothing
   where
   localDefn uri ident = case _.parsed <$> Map.lookup uri parsedModules of
-    Just (ParseSucceeded parsedModule) -> getLocalDefinitions uri position ident parsedModule
-    Just (ParseSucceededWithErrors parsedModule _) -> getLocalDefinitions uri position ident parsedModule
+    Just (ParseSucceeded parsedModule) -> getLocalDefinitions uri position ident
+      parsedModule
+    Just (ParseSucceededWithErrors parsedModule _) -> getLocalDefinitions uri
+      position
+      ident
+      parsedModule
     _ -> pure Nothing
 
   moduleInfo port' { word, qualifier } { right } = do
@@ -102,10 +130,13 @@ getDefinition _notify docs _ state@(ServerState { clientCapabilities: Just clien
             Just { typePos, originRange: Just $ mkNewRange position left right }
           _ -> Nothing
   typeInfo port' modules { word, qualifier } = do
-    info <- getTypeInfo port' word modules.main qualifier (getUnqualActiveModules modules $ Just word) (flip getQualModule modules)
+    info <- getTypeInfo port' word modules.main qualifier
+      (getUnqualActiveModules modules $ Just word)
+      (flip getQualModule modules)
     pure
       $ case info of
-          Just (Command.TypeInfo { definedAt: Just typePos }) -> Just { typePos, originRange: Nothing }
+          Just (Command.TypeInfo { definedAt: Just typePos }) -> Just
+            { typePos, originRange: Nothing }
           _ -> Nothing
 
   mkLineRange pos =
@@ -114,7 +145,10 @@ getDefinition _notify docs _ state@(ServerState { clientCapabilities: Just clien
       , end: pos # over Position (\c -> c { character = c.character + 100 })
       }
   mkNewRange pos left right =
-    Range { start: over Position (_ { character = left }) pos, end: over Position (_ { character = right }) pos }
+    Range
+      { start: over Position (_ { character = left }) pos
+      , end: over Position (_ { character = right }) pos
+      }
   mkResult uri (Just sourceRange) range =
     if locationLinkSupported clientCapabilities then
       let
@@ -123,7 +157,8 @@ getDefinition _notify docs _ state@(ServerState { clientCapabilities: Just clien
             ( \rr ->
                 rr
                   { start = over Position (\pp -> pp { character = 0 }) rr.start
-                  , end = over Position (\pp -> pp { line = pp.line + 1 }) rr.end
+                  , end = over Position (\pp -> pp { line = pp.line + 1 })
+                      rr.end
                   }
             )
             range
@@ -138,58 +173,122 @@ getDefinition _notify docs _ state@(ServerState { clientCapabilities: Just clien
               }
     else
       gotoDefinitionResult $ Left $ Location { uri, range }
-  mkResult uri Nothing range = gotoDefinitionResult $ Left $ Location { uri, range }
+  mkResult uri Nothing range = gotoDefinitionResult $ Left $ Location
+    { uri, range }
 
   locationLinkSupported :: ClientCapabilities -> Boolean
-  locationLinkSupported c = c # (_.textDocument >>> m) >>= (_.definition >>> m) >>= (_.linkSupport >>> m) # isJust
+  locationLinkSupported c = c # (_.textDocument >>> m) >>= (_.definition >>> m)
+    >>= (_.linkSupport >>> m)
+    # isJust
 
   m :: forall a. Nullable a -> Maybe a
   m = Nullable.toMaybe
 getDefinition _ _ _ _ _ = pure $ toNullable Nothing
 
-guard' ∷ ∀ t. Monoid t ⇒ Boolean → (Unit → t) → t
+guard' :: forall t. Monoid t => Boolean -> (Unit -> t) -> t
 guard' cond f = if cond then f unit else mempty
 
-type IdentRange
-  = { ident :: SourceRange, scope :: SourceRange }
+type IdentRange = { ident :: SourceRange, scope :: SourceRange }
 
-newtype DoStatementsScope err
-  = DoStatementsScope (NEA.NonEmptyArray (Either (Expr err) (DoStatement err)))
+newtype DoStatementsScope err = DoStatementsScope
+  (NEA.NonEmptyArray (Either (Expr err) (DoStatement err)))
 
-instance rangeOfDoStatementsScope :: RangeOf err => RangeOf (DoStatementsScope err) where
-  rangeOf (DoStatementsScope stmts) = foldl1 (\a b -> { start: a.start, end: b.end }) $ either rangeOf rangeOf <$> stmts
+instance rangeOfDoStatementsScope ::
+  RangeOf err =>
+  RangeOf (DoStatementsScope err) where
+  rangeOf (DoStatementsScope stmts) =
+    foldl1 (\a b -> { start: a.start, end: b.end }) $ either rangeOf rangeOf <$>
+      stmts
 
-getLocalDefinitions :: ∀ err. RangeOf err => DocumentUri -> Position -> String -> CST.Module err -> Aff (Maybe GotoDefinitionResult)
+getLocalDefinitions ::
+  forall err.
+  RangeOf err =>
+  DocumentUri ->
+  Position ->
+  String ->
+  CST.Module err ->
+  Aff (Maybe GotoDefinitionResult)
 getLocalDefinitions uri position ident mod =
   toRes
-    $ ( CSTTraversals.foldMapModule
+    $
+      ( CSTTraversals.foldMapModule
           $ CSTTraversals.defaultMonoidalVisitor
               { onExpr =
-                \e -> case e of
-                  ExprLet { bindings } -> foldMap (onLetBind e) bindings
-                  ExprLambda { binders, body } -> foldMap (onBinder body) binders
-                  ExprCase { branches } -> foldMap (\(Tuple (Separated { head, tail }) guarded) -> foldMap (onBinder guarded) (head : map snd tail)) branches
-                  ExprDo { statements } -> _.res $ foldr onStmt { scope: [], res: Set.empty } $ NEA.toArray statements
-                  ExprAdo { statements, result } -> _.res $ foldr onStmt { scope: [ Left result ], res: Set.empty } statements
-                  _ -> Set.empty
+                  \e -> case e of
+                    ExprLet { bindings } -> foldMap (onLetBind e) bindings
+                    ExprLambda { binders, body } -> foldMap (onBinder body)
+                      binders
+                    ExprCase { branches } -> foldMap
+                      ( \(Tuple (Separated { head, tail }) guarded) -> foldMap
+                          (onBinder guarded)
+                          (head : map snd tail)
+                      )
+                      branches
+                    ExprDo { statements } -> _.res
+                      $ foldr onStmt { scope: [], res: Set.empty }
+                      $ NEA.toArray statements
+                    ExprAdo { statements, result } -> _.res $ foldr onStmt
+                      { scope: [ Left result ], res: Set.empty }
+                      statements
+                    _ -> Set.empty
               , onDecl =
-                \d ->
-                  let
-                    onMod x token = guard' (x == ident) (\_ -> Set.singleton { ident: token.range, scope: rangeOf mod })
-                  in
-                    case d of
-                      DeclValue { name: CST.Name { name: CST.Ident x, token }, binders } ->
-                        onMod x token <> foldMap (onBinder d) binders
-                      DeclData { name: CST.Name { token, name: CST.Proper name } } _ -> onMod name token
-                      DeclNewtype { name: CST.Name { token, name: CST.Proper name } } _ _ _ -> onMod name token
-                      DeclClass { name: CST.Name { token, name: CST.Proper name } } _ -> onMod name token
-                      DeclType { name: CST.Name { token, name: CST.Proper name } } _ _ -> onMod name token
-                      DeclFixity { operator: CST.FixityValue _ _ (CST.Name { token, name: CST.Operator name }) } -> onMod name token
-                      DeclFixity { operator: CST.FixityType _ _ _ (CST.Name { token, name: CST.Operator name }) } -> onMod name token
-                      DeclForeign _ _ (CST.ForeignValue (CST.Labeled { label: CST.Name { token, name: CST.Ident name } })) -> onMod name token
-                      DeclForeign _ _ (CST.ForeignData _ (CST.Labeled { label: CST.Name { token, name: CST.Proper name } })) -> onMod name token
-                      DeclForeign _ _ (CST.ForeignKind _ (CST.Name { token, name: CST.Proper name })) -> onMod name token
-                      _ -> Set.empty
+                  \d ->
+                    let
+                      onMod x token = guard' (x == ident)
+                        ( \_ -> Set.singleton
+                            { ident: token.range, scope: rangeOf mod }
+                        )
+                    in
+                      case d of
+                        DeclValue
+                          { name: CST.Name { name: CST.Ident x, token }
+                          , binders
+                          } ->
+                          onMod x token <> foldMap (onBinder d) binders
+                        DeclData
+                          { name: CST.Name { token, name: CST.Proper name } }
+                          _ -> onMod name token
+                        DeclNewtype
+                          { name: CST.Name { token, name: CST.Proper name } }
+                          _
+                          _
+                          _ -> onMod name token
+                        DeclClass
+                          { name: CST.Name { token, name: CST.Proper name } }
+                          _ -> onMod name token
+                        DeclType
+                          { name: CST.Name { token, name: CST.Proper name } }
+                          _
+                          _ -> onMod name token
+                        DeclFixity
+                          { operator: CST.FixityValue _ _
+                              (CST.Name { token, name: CST.Operator name })
+                          } -> onMod name token
+                        DeclFixity
+                          { operator: CST.FixityType _ _ _
+                              (CST.Name { token, name: CST.Operator name })
+                          } -> onMod name token
+                        DeclForeign _ _
+                          ( CST.ForeignValue
+                              ( CST.Labeled
+                                  { label: CST.Name
+                                      { token, name: CST.Ident name }
+                                  }
+                              )
+                          ) -> onMod name token
+                        DeclForeign _ _
+                          ( CST.ForeignData _
+                              ( CST.Labeled
+                                  { label: CST.Name
+                                      { token, name: CST.Proper name }
+                                  }
+                              )
+                          ) -> onMod name token
+                        DeclForeign _ _
+                          ( CST.ForeignKind _
+                              (CST.Name { token, name: CST.Proper name })
+                          ) -> onMod name token
+                        _ -> Set.empty
               }
       )
         mod
@@ -197,24 +296,40 @@ getLocalDefinitions uri position ident mod =
 
   onLetBind :: forall e. RangeOf e => e -> LetBinding err -> Set IdentRange
   onLetBind eScope = case _ of
-    CST.LetBindingName { name: CST.Name { name: CST.Ident x, token }, binders, guarded } ->
+    CST.LetBindingName
+      { name: CST.Name { name: CST.Ident x, token }, binders, guarded } ->
       -- TODO scope is not fully e if patterns binds split the block
-      guard' (x == ident) (\_ -> Set.singleton { ident: token.range, scope: rangeOf eScope })
+      guard' (x == ident)
+        (\_ -> Set.singleton { ident: token.range, scope: rangeOf eScope })
         <> foldMap (onBinder guarded) binders
     CST.LetBindingPattern binder _ _ewhere -> onBinder eScope binder -- TODO should be bound in rest of bindings only
 
     _ -> Set.empty
 
-  onStmt :: DoStatement err -> { res :: Set IdentRange, scope :: Array (Either (Expr err) (DoStatement err)) } -> { res :: Set IdentRange, scope :: Array (Either (Expr err) (DoStatement err)) }
+  onStmt ::
+    DoStatement err ->
+    { res :: Set IdentRange
+    , scope :: Array (Either (Expr err) (DoStatement err))
+    } ->
+    { res :: Set IdentRange
+    , scope :: Array (Either (Expr err) (DoStatement err))
+    }
   onStmt stmt acc = case stmt of
     DoLet _ letBinds ->
       let
-        res' = maybe Set.empty (\scopeStmts -> foldMap (onLetBind (DoStatementsScope scopeStmts)) letBinds) $ NEA.fromArray acc.scope
+        res' =
+          maybe Set.empty
+            ( \scopeStmts -> foldMap (onLetBind (DoStatementsScope scopeStmts))
+                letBinds
+            ) $ NEA.fromArray acc.scope
       in
         { res: acc.res <> res', scope: (Right stmt) : acc.scope }
     DoBind binder _ _ ->
       let
-        res' = maybe Set.empty (\scopeStmts -> onBinder (DoStatementsScope scopeStmts) binder) $ NEA.fromArray acc.scope
+        res' =
+          maybe Set.empty
+            (\scopeStmts -> onBinder (DoStatementsScope scopeStmts) binder) $
+            NEA.fromArray acc.scope
       in
         { res: acc.res <> res', scope: (Right stmt) : acc.scope }
     _ -> acc { scope = (Right stmt) : acc.scope }
@@ -224,15 +339,22 @@ getLocalDefinitions uri position ident mod =
     CSTTraversals.foldMapBinder
       $ CSTTraversals.defaultMonoidalVisitor
           { onBinder =
-            case _ of
-              CST.BinderVar (CST.Name { name: CST.Ident x, token }) | x == ident -> Set.singleton { ident: token.range, scope: rangeOf eScope }
-              CST.BinderNamed (CST.Name { name: CST.Ident x, token }) _ _ | x == ident -> Set.singleton { ident: token.range, scope: rangeOf eScope }
+              case _ of
+                CST.BinderVar (CST.Name { name: CST.Ident x, token })
+                  | x == ident -> Set.singleton
+                      { ident: token.range, scope: rangeOf eScope }
+                CST.BinderNamed (CST.Name { name: CST.Ident x, token }) _ _
+                  | x == ident -> Set.singleton
+                      { ident: token.range, scope: rangeOf eScope }
 
-              _ -> Set.empty
+                _ -> Set.empty
           }
 
   (Position { line: targetLine, character: targetChar }) = position
-  containsPosition { start: { line: startLine, column: startCol }, end: { line: endLine, column: endCol } } =
+  containsPosition
+    { start: { line: startLine, column: startCol }
+    , end: { line: endLine, column: endCol }
+    } =
     let
       target = Tuple targetLine targetChar
     in
@@ -240,11 +362,14 @@ getLocalDefinitions uri position ident mod =
 
   toRes :: Set IdentRange -> Aff (Maybe GotoDefinitionResult)
   toRes ranges = do
-    let validRanges = Array.filter (containsPosition <<< _.scope) $ Array.fromFoldable ranges
+    let
+      validRanges = Array.filter (containsPosition <<< _.scope) $
+        Array.fromFoldable ranges
     pure $ (res <<< _.ident) <$> Array.last validRanges
 
   res :: SourceRange -> GotoDefinitionResult
-  res range = gotoDefinitionResult $ Left $ Location { uri, range: sourceRangeToRange range }
+  res range = gotoDefinitionResult $ Left $ Location
+    { uri, range: sourceRangeToRange range }
 
 getDocumentSymbols ::
   Settings ->
@@ -254,7 +379,8 @@ getDocumentSymbols ::
 getDocumentSymbols _ state _ = do
   let { port, root, modules } = un ServerState state
   case port, root of
-    Just port', Just root' -> getSymbols root' port' "" (maybe [] singleton modules.main)
+    Just port', Just root' -> getSymbols root' port' ""
+      (maybe [] singleton modules.main)
     _, _ -> pure []
 
 getWorkspaceSymbols ::
@@ -270,37 +396,40 @@ getWorkspaceSymbols _ state { query } = do
       getSymbols root' port' query allModules
     _, _ -> pure []
 
-getSymbols :: String -> Int -> String -> Array String -> Aff (Array SymbolInformation)
+getSymbols ::
+  String -> Int -> String -> Array String -> Aff (Array SymbolInformation)
 getSymbols root port prefix modules = do
   let opts = CompletionOptions { maxResults: Nothing, groupReexports: true }
-  completions <- getCompletion port prefix Nothing Nothing modules (const []) opts
+  completions <- getCompletion port prefix Nothing Nothing modules (const [])
+    opts
   res <- liftEffect $ traverse getInfo completions
   pure $ catMaybes res
 
   where
-  getInfo (Command.TypeInfo { identifier, definedAt: Just typePos, module' }) = do
-    fileName <- getName typePos
-    let
-      kind =
-        if Str.take 1 identifier == (Str.toUpper $ Str.take 1 identifier) then
-          ClassSymbolKind
-        else if contains (Pattern "->") identifier then
-          FunctionSymbolKind
-        else
-          PropertySymbolKind
-    uri <- filenameToUri fileName
-    pure
-      $ Just
-      $ SymbolInformation
-          { name: identifier
-          , kind: symbolKindToInt kind
-          , location:
-              Location
-                { uri
-                , range: convTypePosition typePos
-                }
-          , containerName: toNullable $ Just $ module'
-          }
+  getInfo (Command.TypeInfo { identifier, definedAt: Just typePos, module' }) =
+    do
+      fileName <- getName typePos
+      let
+        kind =
+          if Str.take 1 identifier == (Str.toUpper $ Str.take 1 identifier) then
+            ClassSymbolKind
+          else if contains (Pattern "->") identifier then
+            FunctionSymbolKind
+          else
+            PropertySymbolKind
+      uri <- filenameToUri fileName
+      pure
+        $ Just
+        $ SymbolInformation
+            { name: identifier
+            , kind: symbolKindToInt kind
+            , location:
+                Location
+                  { uri
+                  , range: convTypePosition typePos
+                  }
+            , containerName: toNullable $ Just $ module'
+            }
   getInfo _ = pure Nothing
 
   getName (Command.TypePosition { name }) = resolve [ root ] name

--- a/src/LanguageServer/IdePurescript/Tooltips.purs
+++ b/src/LanguageServer/IdePurescript/Tooltips.purs
@@ -1,7 +1,6 @@
 module LanguageServer.IdePurescript.Tooltips
   ( getTooltips
-  )
-  where
+  ) where
 
 import Prelude
 
@@ -25,9 +24,15 @@ import Literals.Undefined (undefined)
 import PscIde.Command as C
 import Untagged.Union (asOneOf)
 
-getTooltips :: DocumentStore -> Settings -> ServerState -> TextDocumentPositionParams -> Aff (Nullable Hover)
+getTooltips ::
+  DocumentStore ->
+  Settings ->
+  ServerState ->
+  TextDocumentPositionParams ->
+  Aff (Nullable Hover)
 getTooltips docs _ state ({ textDocument, position }) = toNullable <$> do
-  maybeDoc <- liftEffect $ getDocument docs (_.uri $ un TextDocumentIdentifier textDocument)
+  maybeDoc <- liftEffect $ getDocument docs
+    (_.uri $ un TextDocumentIdentifier textDocument)
   case Nullable.toMaybe maybeDoc of
     Nothing -> pure Nothing
     Just doc -> do
@@ -40,18 +45,21 @@ getTooltips docs _ state ({ textDocument, position }) = toNullable <$> do
           case qualifier of
             Just q
               | char < left + String.length q -> do
-                let mod = getQualModule q (un ServerState state).modules
-                pure
-                  $ case uncons mod of
-                      Just { head } ->
-                        Just
-                          $ Hover
-                              { contents: markupContent head
-                              , range: asOneOf $ wordRange position range { right = left + String.length q }
-                              }
-                      _ -> Nothing
+                  let mod = getQualModule q (un ServerState state).modules
+                  pure
+                    $ case uncons mod of
+                        Just { head } ->
+                          Just
+                            $ Hover
+                                { contents: markupContent head
+                                , range: asOneOf $ wordRange position range
+                                    { right = left + String.length q }
+                                }
+                        _ -> Nothing
             _ -> do
-              ty <- getTypeInfo port' word modules.main qualifier (getUnqualActiveModules modules $ Just word) (flip getQualModule modules)
+              ty <- getTypeInfo port' word modules.main qualifier
+                (getUnqualActiveModules modules $ Just word)
+                (flip getQualModule modules)
               pure $ map (convertInfo word) ty
         _, _ -> pure Nothing
   where
@@ -63,7 +71,9 @@ getTooltips docs _ state ({ textDocument, position }) = toNullable <$> do
       , range: asOneOf undefined
       }
     where
-    typeStr = "```purescript\n" <> compactTypeStr <> (if showExpanded then "\n" <> expandedTypeStr else "") <> "\n```"
+    typeStr = "```purescript\n" <> compactTypeStr
+      <> (if showExpanded then "\n" <> expandedTypeStr else "")
+      <> "\n```"
     showExpanded = isJust expandedType && (expandedType /= Just type')
     compactTypeStr = word <> " :: " <> type'
     expandedTypeStr = word <> " :: " <> (fromMaybe "" expandedType)
@@ -71,27 +81,12 @@ getTooltips docs _ state ({ textDocument, position }) = toNullable <$> do
   wordRange (Position { line }) { left, right } =
     Range
       { start:
-          Position
-            { line
-            , character: left
-            }
-      , end:
-          Position
-            { line
-            , character: right
-            }
+          Position { line, character: left }
+      , end: Position { line, character: right }
       }
 
   lineRange (Position { line, character }) =
     Range
-      { start:
-          Position
-            { line
-            , character: 0
-            }
-      , end:
-          Position
-            { line
-            , character: character + 100
-            }
+      { start: Position { line, character: 0 }
+      , end: Position { line, character: character + 100 }
       }

--- a/src/LanguageServer/IdePurescript/Types.purs
+++ b/src/LanguageServer/IdePurescript/Types.purs
@@ -8,6 +8,7 @@ module LanguageServer.IdePurescript.Types
   ) where
 
 import Prelude
+
 import Data.Map (Map)
 import Data.Maybe (Maybe)
 import Data.Newtype (class Newtype)
@@ -21,54 +22,51 @@ import PscIde.Command (RebuildError)
 import PureScript.CST (RecoveredParserResult)
 import PureScript.CST.Types (Module)
 
-type DiagnosticState
-  = Map DocumentUri
-      { errors :: Array RebuildError
-      , diagnostics :: Array Diagnostic
-      , onType :: Boolean {- if diagnostics came for not saved yet file -}
-      }
+type DiagnosticState = Map DocumentUri
+  { errors :: Array RebuildError
+  , diagnostics :: Array Diagnostic
+  , onType :: Boolean {- if diagnostics came for not saved yet file -}
+  }
 
-type CacheDb
-  = { path :: String, source :: String }
+type CacheDb = { path :: String, source :: String }
 
 data RebuildRunning
   = FullBuild
   | FastRebuild (Map DocumentUri TextDocument)
   | DiagnosticsRebuild (Map DocumentUri TextDocument)
 
-type ServerStateRec
-  = { port :: Maybe Int
-    , root :: Maybe String
-    , conn :: Maybe Connection
-    , clientCapabilities :: Maybe ClientCapabilities
-    , deactivate :: Aff Unit
-    --
-    , runningRebuild ::
-        Maybe { fiber :: Fiber Unit, uri :: DocumentUri, version :: Number }
-    --
-    , rebuildRunning :: Maybe RebuildRunning
-    , fastRebuildQueue :: Map DocumentUri TextDocument
-    , diagnosticsQueue :: Map DocumentUri TextDocument
-    , fullBuildWaiting :: Maybe { progress :: Boolean }
-    --
-    , savedCacheDb :: Maybe CacheDb
-    , revertCacheDbTimeout :: Maybe TimeoutId
-    --
-    , modules :: Modules.State
-    , modulesFile :: Maybe DocumentUri
-    , diagnostics :: DiagnosticState
-    , parsedModules ::
-        Map DocumentUri
-          { version :: Number
-          , parsed :: RecoveredParserResult Module
-          , document :: TextDocument
-          }
-    }
+type ServerStateRec =
+  { port :: Maybe Int
+  , root :: Maybe String
+  , conn :: Maybe Connection
+  , clientCapabilities :: Maybe ClientCapabilities
+  , deactivate :: Aff Unit
+  --
+  , runningRebuild ::
+      Maybe { fiber :: Fiber Unit, uri :: DocumentUri, version :: Number }
+  --
+  , rebuildRunning :: Maybe RebuildRunning
+  , fastRebuildQueue :: Map DocumentUri TextDocument
+  , diagnosticsQueue :: Map DocumentUri TextDocument
+  , fullBuildWaiting :: Maybe { progress :: Boolean }
+  --
+  , savedCacheDb :: Maybe CacheDb
+  , revertCacheDbTimeout :: Maybe TimeoutId
+  --
+  , modules :: Modules.State
+  , modulesFile :: Maybe DocumentUri
+  , diagnostics :: DiagnosticState
+  , parsedModules ::
+      Map DocumentUri
+        { version :: Number
+        , parsed :: RecoveredParserResult Module
+        , document :: TextDocument
+        }
+  }
 
-newtype ServerState
-  = ServerState ServerStateRec
+newtype ServerState = ServerState ServerStateRec
 
 derive instance newtypeServerState :: Newtype ServerState _
 
-type CommandHandler a
-  = DocumentStore -> Settings -> ServerState -> Array Foreign -> Aff a
+type CommandHandler a =
+  DocumentStore -> Settings -> ServerState -> Array Foreign -> Aff a

--- a/src/LanguageServer/IdePurescript/Util.purs
+++ b/src/LanguageServer/IdePurescript/Util.purs
@@ -1,8 +1,7 @@
 module LanguageServer.IdePurescript.Util
   ( launchAffLog
   , maybeParseResult
-  )
-  where
+  ) where
 
 import Prelude
 
@@ -18,8 +17,13 @@ launchAffLog :: forall a. Notify -> Aff a -> Effect (Fiber Unit)
 launchAffLog notify =
   runAff $ either (notify Error <<< show) (const $ pure unit)
 
-maybeParseResult :: forall a. a -> (forall b. RangeOf b => Module b -> a) -> RecoveredParserResult Module -> a
-maybeParseResult default f = 
+maybeParseResult ::
+  forall a.
+  a ->
+  (forall b. RangeOf b => Module b -> a) ->
+  RecoveredParserResult Module ->
+  a
+maybeParseResult default f =
   case _ of
     ParseSucceeded x -> f x
     ParseSucceededWithErrors x _errs -> f x

--- a/src/LanguageServer/IdePurescript/Util/CST.purs
+++ b/src/LanguageServer/IdePurescript/Util/CST.purs
@@ -4,31 +4,31 @@ import Data.Lens (Iso', iso)
 import LanguageServer.Protocol.Types as LSP
 import PureScript.CST.Types as CST
 
-_sourcePosition ∷ Iso' CST.SourcePos LSP.Position
+_sourcePosition :: Iso' CST.SourcePos LSP.Position
 _sourcePosition = iso sourcePosToPosition sourcePosFromPosition
 
-_sourceRange ∷ Iso' CST.SourceRange LSP.Range
+_sourceRange :: Iso' CST.SourceRange LSP.Range
 _sourceRange = iso sourceRangeToRange sourceRangeFromRange
 
-sourceRangeToRange ∷ CST.SourceRange -> LSP.Range
+sourceRangeToRange :: CST.SourceRange -> LSP.Range
 sourceRangeToRange sr =
   LSP.Range
     { start: sourcePosToPosition sr.start
     , end: sourcePosToPosition sr.end
     }
 
-sourceRangeFromRange ∷ LSP.Range -> CST.SourceRange
+sourceRangeFromRange :: LSP.Range -> CST.SourceRange
 sourceRangeFromRange (LSP.Range lspRange) =
-    { start: sourcePosFromPosition lspRange.start
-    , end:  sourcePosFromPosition lspRange.end
-    }
+  { start: sourcePosFromPosition lspRange.start
+  , end: sourcePosFromPosition lspRange.end
+  }
 
 -- SourcePos are 0 based 
-sourcePosToPosition ∷ CST.SourcePos -> LSP.Position
+sourcePosToPosition :: CST.SourcePos -> LSP.Position
 sourcePosToPosition { line, column } = do
   LSP.Position { line: line, character: column }
 
 -- SourcePos are 0 based 
-sourcePosFromPosition ∷ LSP.Position -> CST.SourcePos
+sourcePosFromPosition :: LSP.Position -> CST.SourcePos
 sourcePosFromPosition (LSP.Position { line, character }) = do
   { line: line, column: character }

--- a/src/LanguageServer/IdePurescript/Util/Position.purs
+++ b/src/LanguageServer/IdePurescript/Util/Position.purs
@@ -1,6 +1,7 @@
 module LanguageServer.IdePurescript.Util.Position where
 
 import Prelude
+
 import Data.Lens (Iso', Lens', iso, over)
 import Data.Lens.Iso.Newtype (_Newtype)
 import Data.Lens.Record (prop)
@@ -9,27 +10,27 @@ import PscIde.Command as PscIde
 import Type.Proxy (Proxy(..))
 
 -- Some Lenses
-_line ∷ Lens' LSP.Position Int
-_line = _Newtype <<< prop (Proxy ∷ Proxy "line")
+_line :: Lens' LSP.Position Int
+_line = _Newtype <<< prop (Proxy :: Proxy "line")
 
-_character ∷ Lens' LSP.Position Int
-_character = _Newtype <<< prop (Proxy ∷ Proxy "character")
+_character :: Lens' LSP.Position Int
+_character = _Newtype <<< prop (Proxy :: Proxy "character")
 
-_startPosition ∷ Lens' LSP.Range LSP.Position
-_startPosition = _Newtype <<< prop (Proxy ∷ Proxy "start")
+_startPosition :: Lens' LSP.Range LSP.Position
+_startPosition = _Newtype <<< prop (Proxy :: Proxy "start")
 
-_endPosition ∷ Lens' LSP.Range LSP.Position
-_endPosition = _Newtype <<< prop (Proxy ∷ Proxy "end")
+_endPosition :: Lens' LSP.Range LSP.Position
+_endPosition = _Newtype <<< prop (Proxy :: Proxy "end")
 
-shiftRangeDown ∷ Int -> LSP.Range -> LSP.Range
+shiftRangeDown :: Int -> LSP.Range -> LSP.Range
 shiftRangeDown by =
   over (_startPosition <<< _line) (_ + by)
     <<< over (_endPosition <<< _line) (_ + by)
 
 shiftRangeUp :: Int -> LSP.Range -> LSP.Range
-shiftRangeUp = negate >>> shiftRangeDown 
+shiftRangeUp = negate >>> shiftRangeDown
 
-isoPscIdeLspPosition ∷ Iso' PscIde.Position LSP.Position
+isoPscIdeLspPosition :: Iso' PscIde.Position LSP.Position
 isoPscIdeLspPosition = iso convertPosition lspPositionToPscIdePosition
 
 shiftPositionDown :: Int -> LSP.Position -> LSP.Position
@@ -44,28 +45,27 @@ shiftPositionRight by = over _character (_ + by)
 shiftPositionLeft :: Int -> LSP.Position -> LSP.Position
 shiftPositionLeft by = over _character (_ + by)
 
-
-convertPosition ∷ PscIde.Position -> LSP.Position
+convertPosition :: PscIde.Position -> LSP.Position
 convertPosition { line, column } =
   LSP.Position
     { line: line - 1
     , character: column - 1
     }
 
-lspPositionToPscIdePosition ∷ LSP.Position -> PscIde.Position
+lspPositionToPscIdePosition :: LSP.Position -> PscIde.Position
 lspPositionToPscIdePosition (LSP.Position { line, character }) =
   { line: line + 1
   , column: character + 1
   }
 
-convertTypePosition ∷ PscIde.TypePosition -> LSP.Range
+convertTypePosition :: PscIde.TypePosition -> LSP.Range
 convertTypePosition (PscIde.TypePosition { start, end }) =
   LSP.Range
     { start: convertPosition start
     , end: convertPosition end
     }
 
-convertRangePosition ∷ PscIde.RangePosition -> LSP.Range
+convertRangePosition :: PscIde.RangePosition -> LSP.Range
 convertRangePosition { startLine, startColumn, endLine, endColumn } =
   LSP.Range
     { start: convertPosition { line: startLine, column: startColumn }

--- a/src/LanguageServer/IdePurescript/WatchedFiles.purs
+++ b/src/LanguageServer/IdePurescript/WatchedFiles.purs
@@ -1,7 +1,6 @@
 module LanguageServer.IdePurescript.WatchedFiles
   ( handleDidChangeWatchedFiles
-  )
-  where
+  ) where
 
 import Prelude
 
@@ -28,24 +27,29 @@ import LanguageServer.Protocol.Text (makeWorkspaceEdit)
 import LanguageServer.Protocol.TextDocument (getTextAtVersion)
 import LanguageServer.Protocol.Types (Connection, DocumentStore, DocumentUri(..), FileChangeType(..), FileEvent(..), fromFileChangeTypeCode)
 
-handleDidChangeWatchedFiles ∷
+handleDidChangeWatchedFiles ::
   Ref Foreign ->
   Connection ->
-  Ref ServerState -> DocumentStore -> DidChangeWatchedFilesParams -> Aff Unit
+  Ref ServerState ->
+  DocumentStore ->
+  DidChangeWatchedFilesParams ->
+  Aff Unit
 handleDidChangeWatchedFiles configRef conn stateRef documents { changes } = do
   for_ changes \(FileEvent { uri, "type": fileChangeTypeCode }) ->
     case FileTypes.uriToRelevantFileType uri of
-      FileTypes.PureScriptFile -> case fromFileChangeTypeCode fileChangeTypeCode of
-        Just CreatedChangeType -> handleFileCreated configRef conn stateRef documents uri
-        _ -> pure unit
-      FileTypes.JavaScriptFile -> ifJsFileEvaluatePsFfi stateRef documents uri 
+      FileTypes.PureScriptFile ->
+        case fromFileChangeTypeCode fileChangeTypeCode of
+          Just CreatedChangeType -> handleFileCreated configRef conn stateRef
+            documents
+            uri
+          _ -> pure unit
+      FileTypes.JavaScriptFile -> ifJsFileEvaluatePsFfi stateRef documents uri
       FileTypes.UnsupportedFile -> pure unit
-
-
 
 -- | JS files may in PureScript project may be used for FFI
 -- | When a JS file change is passed, check for an associated PS file and queue a fast rebuild
-ifJsFileEvaluatePsFfi :: Ref ServerState -> DocumentStore -> DocumentUri -> Aff Unit
+ifJsFileEvaluatePsFfi ::
+  Ref ServerState -> DocumentStore -> DocumentUri -> Aff Unit
 ifJsFileEvaluatePsFfi serverStateRef documentStore documentUri =
   case FileTypes.jsUriToMayPsUri documentUri of
     Nothing -> pure unit
@@ -56,39 +60,55 @@ ifJsFileEvaluatePsFfi serverStateRef documentStore documentUri =
       case mayDoc of
         Nothing -> pure unit
         Just doc -> queueForFastBuild serverStateRef psUri doc
-    where
-      queueForFastBuild ssRef docUri textDocument = (flip Ref.modify_)
-        ssRef
-        \(ServerState ss) -> ServerState ss{fastRebuildQueue=Map.insert docUri textDocument ss.fastRebuildQueue}
+  where
+  queueForFastBuild ssRef docUri textDocument = (flip Ref.modify_)
+    ssRef
+    \(ServerState ss) -> ServerState ss
+      { fastRebuildQueue = Map.insert docUri textDocument ss.fastRebuildQueue }
 
-
-handleFileCreated ∷
-  Ref Foreign -> Connection -> Ref ServerState -> DocumentStore -> DocumentUri -> Aff Unit
+handleFileCreated ::
+  Ref Foreign ->
+  Connection ->
+  Ref ServerState ->
+  DocumentStore ->
+  DocumentUri ->
+  Aff Unit
 handleFileCreated configRef connection stateRef documents uri = do
   insertModuleHeader configRef connection stateRef documents uri
 
 -- | Adds the first line module X.Y.Z where to the document based on its path.
 -- | Only does so when the file is empty
-insertModuleHeader ∷ Ref Foreign -> Connection -> Ref ServerState -> DocumentStore -> DocumentUri -> Aff Unit
+insertModuleHeader ::
+  Ref Foreign ->
+  Connection ->
+  Ref ServerState ->
+  DocumentStore ->
+  DocumentUri ->
+  Aff Unit
 insertModuleHeader configRef connection stateRef documents uri = do
   ServerState { clientCapabilities } <- liftEffect $ Ref.read stateRef
   maybeDoc <- liftEffect $ getDocument documents uri
-  for_ (Nullable.toMaybe maybeDoc) \doc -> do 
+  for_ (Nullable.toMaybe maybeDoc) \doc -> do
     { text, version } <- liftEffect $ getTextAtVersion doc
     when (text == "") do
       for_ (inferModuleName uri) \inferredModuleName -> do
         config <- liftEffect $ Ref.read configRef
         let
           preludeModule = Config.preludeModule config
-          toInsert = "module " <> inferredModuleName <> " where\n\nimport " <> preludeModule <> "\n"
-          edit = makeWorkspaceEdit clientCapabilities uri version (lineRange' 0 (String.length toInsert)) toInsert
+          toInsert = "module " <> inferredModuleName <> " where\n\nimport "
+            <> preludeModule
+            <> "\n"
+          edit = makeWorkspaceEdit clientCapabilities uri version
+            (lineRange' 0 (String.length toInsert))
+            toInsert
         applyEdit connection edit
 
-inferModuleName ∷ DocumentUri -> Maybe String
+inferModuleName :: DocumentUri -> Maybe String
 inferModuleName (DocumentUri uri) = ado
-  nameWithoutExtension <- case String.stripSuffix (String.Pattern ".purs") uri of
-    Nothing -> String.stripSuffix (String.Pattern ".js") uri
-    Just x -> Just x
+  nameWithoutExtension <-
+    case String.stripSuffix (String.Pattern ".purs") uri of
+      Nothing -> String.stripSuffix (String.Pattern ".js") uri
+      Just x -> Just x
   in moduleNameFromFolderStructure nameWithoutExtension
 
 -- | Guesses the module name from the folder structure
@@ -96,13 +116,16 @@ inferModuleName (DocumentUri uri) = ado
 -- | start with a capital letter (such as "src" or "test")
 -- | Then glues them together with a dot
 -- | Expects a string that has no ".purs" extension
-moduleNameFromFolderStructure ∷ String -> String
+moduleNameFromFolderStructure :: String -> String
 moduleNameFromFolderStructure path =
   let
     dirs = String.split (String.Pattern "/") path
-    parentIndex = fromMaybe (-1) $ Array.findLastIndex (not <<< startsWithCapitalLetter) dirs
+    parentIndex = fromMaybe (-1) $ Array.findLastIndex
+      (not <<< startsWithCapitalLetter)
+      dirs
     parts = Array.drop (parentIndex + 1) dirs
     parts' = case dirs !! parentIndex of
-              Just "test" | parts !! 0 /= Just "Test" -> "Test" : parts
-              _ -> parts
-  in String.joinWith "." parts'
+      Just "test" | parts !! 0 /= Just "Test" -> "Test" : parts
+      _ -> parts
+  in
+    String.joinWith "." parts'

--- a/src/LanguageServer/Protocol/Console.purs
+++ b/src/LanguageServer/Protocol/Console.purs
@@ -1,6 +1,7 @@
 module LanguageServer.Protocol.Console where
 
 import Prelude
+
 import Effect (Effect)
 import LanguageServer.Protocol.Types (Connection)
 

--- a/src/LanguageServer/Protocol/DocumentStore.purs
+++ b/src/LanguageServer/Protocol/DocumentStore.purs
@@ -9,12 +9,19 @@ import LanguageServer.Protocol.Types (DocumentStore, DocumentUri)
 
 foreign import getDocuments :: DocumentStore -> Effect (Array TextDocument)
 
-foreign import getDocument :: DocumentStore -> DocumentUri -> Effect (Nullable TextDocument)
+foreign import getDocument ::
+  DocumentStore -> DocumentUri -> Effect (Nullable TextDocument)
 
-type TextDocumentChangeEvent
-  = { document :: TextDocument }
+type TextDocumentChangeEvent = { document :: TextDocument }
 
-foreign import onDidSaveDocument :: DocumentStore -> (TextDocumentChangeEvent -> Effect Unit) -> Effect Unit
-foreign import onDidOpenDocument :: DocumentStore -> (TextDocumentChangeEvent -> Effect Unit) -> Effect Unit
-foreign import onDidCloseDocument :: DocumentStore -> (TextDocumentChangeEvent -> Effect Unit) -> Effect Unit
-foreign import onDidChangeContent :: DocumentStore -> (TextDocumentChangeEvent -> Effect Unit) -> Effect Unit
+foreign import onDidSaveDocument ::
+  DocumentStore -> (TextDocumentChangeEvent -> Effect Unit) -> Effect Unit
+
+foreign import onDidOpenDocument ::
+  DocumentStore -> (TextDocumentChangeEvent -> Effect Unit) -> Effect Unit
+
+foreign import onDidCloseDocument ::
+  DocumentStore -> (TextDocumentChangeEvent -> Effect Unit) -> Effect Unit
+
+foreign import onDidChangeContent ::
+  DocumentStore -> (TextDocumentChangeEvent -> Effect Unit) -> Effect Unit

--- a/src/LanguageServer/Protocol/Handlers.purs
+++ b/src/LanguageServer/Protocol/Handlers.purs
@@ -10,75 +10,104 @@ import Effect.Aff (Aff)
 import Foreign (Foreign)
 import LanguageServer.Protocol.Types (CodeActionKind(..), CodeActionResult, Command, CompletionItemList, Connection, Diagnostic, DocumentUri, FileEvent, FoldingRange, GotoDefinitionResult, Hover, Location, Position, Range, SymbolInformation, TextDocumentIdentifier, TextEdit, WorkspaceEdit)
 
-type TextDocumentPositionParams
-  = { textDocument :: TextDocumentIdentifier, position :: Position }
+type TextDocumentPositionParams =
+  { textDocument :: TextDocumentIdentifier, position :: Position }
 
-type DocumentSymbolParams
-  = { textDocument :: TextDocumentIdentifier }
-type ReferenceParams
-  = TextDocumentPositionParams
-type WorkspaceSymbolParams
-  = { query :: String }
+type DocumentSymbolParams = { textDocument :: TextDocumentIdentifier }
 
-type CodeActionParams
-  = { textDocument :: TextDocumentIdentifier, range :: Range, context :: CodeActionContext }
-type CodeActionContext
-  = { diagnostics :: Array Diagnostic, only :: Nullable (Array CodeActionKind) }
+type ReferenceParams = TextDocumentPositionParams
 
-type CodeLensParams = { textDocument ∷ TextDocumentIdentifier }
+type WorkspaceSymbolParams = { query :: String }
+
+type CodeActionParams =
+  { textDocument :: TextDocumentIdentifier
+  , range :: Range
+  , context :: CodeActionContext
+  }
+
+type CodeActionContext =
+  { diagnostics :: Array Diagnostic, only :: Nullable (Array CodeActionKind) }
+
+type CodeLensParams = { textDocument :: TextDocumentIdentifier }
 
 type CodeLensResult =
-  { range ∷ Range 
+  { range :: Range
   , command :: Nullable Command
   , data :: Foreign
   }
 
 type FoldingRangesParams = { textDocument :: TextDocumentIdentifier }
 
-type DocumentFormattingParams
-  = { textDocument :: TextDocumentIdentifier }
+type DocumentFormattingParams = { textDocument :: TextDocumentIdentifier }
 
-type DidChangeConfigurationParams
-  = { settings :: Foreign }
+type DidChangeConfigurationParams = { settings :: Foreign }
 
-type PublishDiagnosticParams
-  = { uri :: DocumentUri, diagnostics :: Array Diagnostic }
-type ExecuteCommandParams
-  = { command :: String, arguments :: Array Foreign }
+type PublishDiagnosticParams =
+  { uri :: DocumentUri, diagnostics :: Array Diagnostic }
 
-type DidChangeWatchedFilesParams
-  = { changes :: Array FileEvent }
+type ExecuteCommandParams = { command :: String, arguments :: Array Foreign }
 
-type Res a
-  = Effect (Promise a)
+type DidChangeWatchedFilesParams = { changes :: Array FileEvent }
 
-foreign import onDefinition :: Connection -> (TextDocumentPositionParams -> Res (Nullable GotoDefinitionResult)) -> Effect Unit
+type Res a = Effect (Promise a)
 
-foreign import onCompletion :: Connection -> (TextDocumentPositionParams -> Res CompletionItemList) -> Effect Unit
+foreign import onDefinition ::
+  Connection ->
+  (TextDocumentPositionParams -> Res (Nullable GotoDefinitionResult)) ->
+  Effect Unit
 
-foreign import onHover :: Connection -> (TextDocumentPositionParams -> Res (Nullable Hover)) -> Effect Unit
+foreign import onCompletion ::
+  Connection ->
+  (TextDocumentPositionParams -> Res CompletionItemList) ->
+  Effect Unit
 
-foreign import onDocumentSymbol :: Connection -> (DocumentSymbolParams -> Res (Array SymbolInformation)) -> Effect Unit
+foreign import onHover ::
+  Connection ->
+  (TextDocumentPositionParams -> Res (Nullable Hover)) ->
+  Effect Unit
 
-foreign import onWorkspaceSymbol :: Connection -> (WorkspaceSymbolParams -> Res (Array SymbolInformation)) -> Effect Unit
+foreign import onDocumentSymbol ::
+  Connection ->
+  (DocumentSymbolParams -> Res (Array SymbolInformation)) ->
+  Effect Unit
 
-foreign import onReferences :: Connection -> (ReferenceParams -> Res (Array Location)) -> Effect Unit
+foreign import onWorkspaceSymbol ::
+  Connection ->
+  (WorkspaceSymbolParams -> Res (Array SymbolInformation)) ->
+  Effect Unit
 
-foreign import onCodeAction :: Connection -> (CodeActionParams -> Res (Array CodeActionResult)) -> Effect Unit
+foreign import onReferences ::
+  Connection -> (ReferenceParams -> Res (Array Location)) -> Effect Unit
 
-foreign import onCodeLens ∷ Connection -> (CodeLensParams -> Res (Array CodeLensResult)) -> Effect Unit
+foreign import onCodeAction ::
+  Connection ->
+  (CodeActionParams -> Res (Array CodeActionResult)) ->
+  Effect Unit
 
-foreign import onFoldingRanges :: Connection -> (FoldingRangesParams -> Res (Array FoldingRange)) -> Effect Unit
+foreign import onCodeLens ::
+  Connection -> (CodeLensParams -> Res (Array CodeLensResult)) -> Effect Unit
 
-foreign import onDocumentFormatting :: Connection -> (DocumentFormattingParams -> Res (Array TextEdit)) -> Effect Unit
+foreign import onFoldingRanges ::
+  Connection -> (FoldingRangesParams -> Res (Array FoldingRange)) -> Effect Unit
 
-foreign import onDidChangeConfiguration :: Connection -> (DidChangeConfigurationParams -> Effect Unit) -> Effect Unit
+foreign import onDocumentFormatting ::
+  Connection ->
+  (DocumentFormattingParams -> Res (Array TextEdit)) ->
+  Effect Unit
 
-foreign import onDidChangeWatchedFiles :: Connection -> (DidChangeWatchedFilesParams -> Effect Unit) -> Effect Unit
+foreign import onDidChangeConfiguration ::
+  Connection -> (DidChangeConfigurationParams -> Effect Unit) -> Effect Unit
 
-foreign import onExecuteCommand :: Connection -> (ExecuteCommandParams -> Effect (Promise Foreign)) -> Effect Unit
+foreign import onDidChangeWatchedFiles ::
+  Connection -> (DidChangeWatchedFilesParams -> Effect Unit) -> Effect Unit
 
-foreign import publishDiagnostics :: Connection -> PublishDiagnosticParams -> Effect Unit
+foreign import onExecuteCommand ::
+  Connection ->
+  (ExecuteCommandParams -> Effect (Promise Foreign)) ->
+  Effect Unit
+
+foreign import publishDiagnostics ::
+  Connection -> PublishDiagnosticParams -> Effect Unit
 
 foreign import applyEditImpl :: Connection -> WorkspaceEdit -> Res Boolean
 

--- a/src/LanguageServer/Protocol/Setup.js
+++ b/src/LanguageServer/Protocol/Setup.js
@@ -6,7 +6,7 @@ export var initConnection = function (commands) {
             var conn = createConnection();
             conn.listen();
             conn.onInitialize(function (params) {
-                conn.console.info(JSON.stringify(params));
+                // conn.console.info(JSON.stringify(params));
                 cb({
                     params: params,
                     conn: conn,

--- a/src/LanguageServer/Protocol/Setup.js
+++ b/src/LanguageServer/Protocol/Setup.js
@@ -1,4 +1,4 @@
-import { createConnection, TextDocuments, CodeActionKind, TextDocumentSyncKind } from "vscode-languageserver/node";
+import { createConnection, TextDocuments, CodeActionKind, TextDocumentSyncKind, } from "vscode-languageserver/node";
 import { TextDocument } from "vscode-languageserver-textdocument";
 export var initConnection = function (commands) {
     return function (cb) {

--- a/src/LanguageServer/Protocol/Setup.purs
+++ b/src/LanguageServer/Protocol/Setup.purs
@@ -1,6 +1,7 @@
 module LanguageServer.Protocol.Setup where
 
 import Prelude
+
 import Control.Promise (Promise)
 import Control.Promise as Promise
 import Data.Nullable (Nullable)
@@ -9,15 +10,19 @@ import Effect.Aff (Aff)
 import Foreign (Foreign)
 import LanguageServer.Protocol.Types (ClientCapabilities, Connection, DocumentStore, DocumentUri)
 
-newtype InitParams
-  = InitParams { rootUri :: Nullable DocumentUri, rootPath :: Nullable String, trace :: Nullable String, capabilities :: ClientCapabilities }
-type InitResult
-  = { conn :: Connection, params :: InitParams }
+newtype InitParams = InitParams
+  { rootUri :: Nullable DocumentUri
+  , rootPath :: Nullable String
+  , trace :: Nullable String
+  , capabilities :: ClientCapabilities
+  }
 
-type Res a
-  = Effect (Promise a)
+type InitResult = { conn :: Connection, params :: InitParams }
 
-foreign import initConnection :: Array String -> (InitResult -> Effect Unit) -> Effect Connection
+type Res a = Effect (Promise a)
+
+foreign import initConnection ::
+  Array String -> (InitResult -> Effect Unit) -> Effect Connection
 
 foreign import initDocumentStore :: Connection -> Effect DocumentStore
 

--- a/src/LanguageServer/Protocol/Setup.ts
+++ b/src/LanguageServer/Protocol/Setup.ts
@@ -5,7 +5,7 @@ import {
   TextDocuments,
   CodeActionKind,
   LSPObject,
-  TextDocumentSyncKind
+  TextDocumentSyncKind,
 } from "vscode-languageserver/node";
 import { TextDocument } from "vscode-languageserver-textdocument";
 
@@ -17,7 +17,7 @@ export const initConnection =
     conn.listen();
 
     conn.onInitialize((params) => {
-      conn.console.info(JSON.stringify(params));
+      // conn.console.info(JSON.stringify(params));
       cb({
         params,
         conn,

--- a/src/LanguageServer/Protocol/Text.purs
+++ b/src/LanguageServer/Protocol/Text.purs
@@ -13,44 +13,67 @@ import Data.String.Regex.Flags (noFlags)
 import Data.Tuple (uncurry)
 import LanguageServer.Protocol.Types (ClientCapabilities, DocumentUri, OptionalVersionedTextDocumentIdentifier(..), Position(..), Range(..), TextDocumentEdit(..), TextEdit(..), WorkspaceEdit, workspaceEdit)
 
-makeWorkspaceEdit :: Maybe ClientCapabilities -> DocumentUri -> Number -> Range -> String -> WorkspaceEdit
-makeWorkspaceEdit capabilities uri version range newText = workspaceEdit capabilities [ edit ]
-  where 
-      textEdit = TextEdit { range, newText }
-      docid = OptionalVersionedTextDocumentIdentifier { uri, version: Nullable.notNull version }
-      edit = TextDocumentEdit { textDocument: docid, edits: [ textEdit ] }
+makeWorkspaceEdit ::
+  Maybe ClientCapabilities ->
+  DocumentUri ->
+  Number ->
+  Range ->
+  String ->
+  WorkspaceEdit
+makeWorkspaceEdit capabilities uri version range newText = workspaceEdit
+  capabilities
+  [ edit ]
+  where
+  textEdit = TextEdit { range, newText }
+  docid = OptionalVersionedTextDocumentIdentifier
+    { uri, version: Nullable.notNull version }
+  edit = TextDocumentEdit { textDocument: docid, edits: [ textEdit ] }
 
--- | Make a full-text workspace edit via a minimal diff under the assumption that at most one change is required
--- | In particular the scenario of inserting text in the middle AC -> ABC becomes an edit of B only.
-makeMinimalWorkspaceEdit :: Maybe ClientCapabilities -> DocumentUri -> Number -> String -> String -> Maybe WorkspaceEdit
+-- | Make a full-text workspace edit via a minimal diff under the assumption
+-- | that at most one change is required In particular the scenario of inserting
+-- | text in the middle AC -> ABC becomes an edit of B only.
+makeMinimalWorkspaceEdit ::
+  Maybe ClientCapabilities ->
+  DocumentUri ->
+  Number ->
+  String ->
+  String ->
+  Maybe WorkspaceEdit
 makeMinimalWorkspaceEdit clientCapabilities uri version oldText newText =
-  let splitLines t = either (const [t]) (\r -> Regex.split r t) $ regex "\r?\n" noFlags
-      newLines = splitLines newText
-      oldLines = case splitLines oldText of
-        -- Add imports adds a newline to the end of the file always, giving bad diffs
-        xs | last xs /= Just "" && last newLines == Just "" -> xs <> [""]
-        xs -> xs
+  let
+    splitLines t = either (const [ t ]) (\r -> Regex.split r t) $ regex "\r?\n"
+      noFlags
+    newLines = splitLines newText
+    oldLines = case splitLines oldText of
+      -- Add imports adds a newline to the end of the file always, giving bad diffs
+      xs | last xs /= Just "" && last newLines == Just "" -> xs <> [ "" ]
+      xs -> xs
 
-      range text l1 l2 = Range
-        { start: Position { line: l1, character: 0 },
-          end: Position { line: length text - l2 , character: 0 }
-        }
-      lines text l1 l2 = slice l1 (length text - l2 ) text
+    range text l1 l2 = Range
+      { start: Position { line: l1, character: 0 }
+      , end: Position { line: length text - l2, character: 0 }
+      }
+    lines text l1 l2 = slice l1 (length text - l2) text
 
-      firstDiff = findIndex (uncurry (/=)) (zip oldLines newLines)
-      lastDiff = findIndex (uncurry (/=)) (zip (reverse oldLines) (reverse newLines))
+    firstDiff = findIndex (uncurry (/=)) (zip oldLines newLines)
+    lastDiff = findIndex (uncurry (/=))
+      (zip (reverse oldLines) (reverse newLines))
 
-      e a b = Just $ makeWorkspaceEdit clientCapabilities uri version a b
-      oldLen = length oldLines
-      newLen = length newLines
+    e a b = Just $ makeWorkspaceEdit clientCapabilities uri version a b
+    oldLen = length oldLines
+    newLen = length newLines
 
-  in case firstDiff, lastDiff of
+  in
+    case firstDiff, lastDiff of
       Just n, Just m
-        | newLen - m >= n
-          -> 
-          let m' = min m (oldLen - n) in
-          e (range oldLines n m') (joinWith "\n" (lines newLines n m') <> if null newLines then "" else "\n")
+        | newLen - m >= n ->
+            let
+              m' = min m (oldLen - n)
+            in
+              e (range oldLines n m')
+                ( joinWith "\n" (lines newLines n m') <>
+                    if null newLines then "" else "\n"
+                )
       Nothing, Nothing
         | oldLen == newLen -> Nothing
       _, _ -> e (range oldLines 0 0) newText
-

--- a/src/LanguageServer/Protocol/TextDocument.purs
+++ b/src/LanguageServer/Protocol/TextDocument.purs
@@ -1,6 +1,7 @@
 module LanguageServer.Protocol.TextDocument where
 
 import Prelude
+
 import Effect (Effect)
 import LanguageServer.Protocol.Types (DocumentUri, Position, Range)
 

--- a/src/LanguageServer/Protocol/Types.purs
+++ b/src/LanguageServer/Protocol/Types.purs
@@ -21,36 +21,38 @@ import Untagged.Union (UndefinedOr)
 foreign import data Connection :: Type
 foreign import data DocumentStore :: Type
 
-type MarkedString
-  = { language :: String, value :: String }
+type MarkedString = { language :: String, value :: String }
 
 markedString :: String -> MarkedString
 markedString s = { language: "purescript", value: s }
 
-type MarkupContent
-  = { kind :: String, value :: String }
+type MarkupContent = { kind :: String, value :: String }
 
 markupContent :: String -> MarkupContent
 markupContent s = { kind: "markdown", value: s }
 
 derive instance newtypeDocumentUri :: Newtype DocumentUri _
 
-newtype DocumentUri
-  = DocumentUri String
+newtype DocumentUri = DocumentUri String
+
 instance showDocumentUri :: Show DocumentUri where
   show (DocumentUri uri) = "DocumentUri " <> show uri
 
 derive newtype instance eqDocumentUri :: Eq DocumentUri
 derive newtype instance Ord DocumentUri
 
-newtype Position
-  = Position { line :: Int, character :: Int }
+newtype Position = Position { line :: Int, character :: Int }
 
 instance eqPosition :: Eq Position where
-  eq (Position { line, character }) (Position { line: line', character: character' }) = line == line' && character == character'
+  eq
+    (Position { line, character })
+    (Position { line: line', character: character' }) = line == line' &&
+    character == character'
 
 instance positionOrd :: Ord Position where
-  compare (Position { line: line, character: character }) (Position { line: line', character: character' })
+  compare
+    (Position { line: line, character: character })
+    (Position { line: line', character: character' })
     | line < line' = LT
     | line == line' && character < character' = LT
     | line == line' && character == character' = EQ
@@ -59,16 +61,19 @@ instance positionOrd :: Ord Position where
 derive instance newtypePosition :: Newtype Position _
 
 instance showPosition :: Show Position where
-  show (Position { line, character }) = "Position(" <> show line <> "," <> show character <> ")"
+  show (Position { line, character }) = "Position(" <> show line <> ","
+    <> show character
+    <> ")"
 
-newtype Range
-  = Range { start :: Position, end :: Position }
+newtype Range = Range { start :: Position, end :: Position }
 
 instance eqRange :: Eq Range where
-  eq (Range { start, end }) (Range { start: start', end: end' }) = start == start' && end == end'
+  eq (Range { start, end }) (Range { start: start', end: end' }) =
+    start == start' && end == end'
 
 instance ordRange :: Ord Range where
-  compare (Range { start, end }) (Range { start: start', end: end' }) = compare start start' <> compare end end'
+  compare (Range { start, end }) (Range { start: start', end: end' }) =
+    compare start start' <> compare end end'
 
 instance showRange :: Show Range where
   show (Range { start, end }) = "Range(" <> show start <> "," <> show end <> ")"
@@ -86,38 +91,39 @@ readRange r = do
     character <- p ! "character" >>= readInt
     pure $ Position { line, character }
 
-newtype Location
-  = Location { uri :: DocumentUri, range :: Range }
+newtype Location = Location { uri :: DocumentUri, range :: Range }
 
 derive instance newtypeLocation :: Newtype Location _
 
-newtype LocationLink
-  = LocationLink { originSelectionRange :: Nullable Range, targetUri :: DocumentUri, targetRange :: Range, targetSelectionRange :: Range }
+newtype LocationLink = LocationLink
+  { originSelectionRange :: Nullable Range
+  , targetUri :: DocumentUri
+  , targetRange :: Range
+  , targetSelectionRange :: Range
+  }
 
 foreign import data GotoDefinitionResult :: Type
 
 gotoDefinitionResult :: Either Location LocationLink -> GotoDefinitionResult
 gotoDefinitionResult = either unsafeCoerce unsafeCoerce
 
-newtype Diagnostic
-  = Diagnostic
+newtype Diagnostic = Diagnostic
   { range :: Range
   , severity :: Nullable Int -- 1 (Error) - 4 (Hint)
   , code :: Nullable String -- String | Int
   , source :: Nullable String
   , message :: String
   }
+
 derive instance newtypeDiagnostic :: Newtype Diagnostic _
 derive newtype instance showDiagnostic :: Show Diagnostic
 
-newtype CompletionItemLabelDetails
-  = CompletionItemLabelDetails
+newtype CompletionItemLabelDetails = CompletionItemLabelDetails
   { detail :: Nullable String
   , description :: Nullable String
   }
 
-newtype CompletionItem
-  = CompletionItem
+newtype CompletionItem = CompletionItem
   { label :: String
   , kind :: Nullable Int
   , detail :: Nullable String
@@ -170,7 +176,8 @@ defaultCompletionItem label =
     }
 
 completionItem :: String -> CompletionItemKind -> CompletionItem
-completionItem label k = defaultCompletionItem label # over CompletionItem (_ { kind = toNullable $ Just $ completionItemKindToInt k })
+completionItem label k = defaultCompletionItem label # over CompletionItem
+  (_ { kind = toNullable $ Just $ completionItemKindToInt k })
 
 completionItemKindToInt :: CompletionItemKind -> Int
 completionItemKindToInt = case _ of
@@ -193,15 +200,14 @@ completionItemKindToInt = case _ of
   File -> 17
   Reference -> 18
 
-newtype CompletionItemList
-  = CompletionItemList
+newtype CompletionItemList = CompletionItemList
   { isIncomplete :: Boolean
   , items :: Array CompletionItem
   }
+
 derive instance newtypeCompletionList :: Newtype CompletionItemList _
 
-newtype SymbolInformation
-  = SymbolInformation
+newtype SymbolInformation = SymbolInformation
   { name :: String
   , kind :: Int
   , location :: Location
@@ -249,19 +255,17 @@ symbolKindToInt = case _ of
   BooleanSymbolKind -> 17
   ArraySymbolKind -> 18
 
-newtype Hover
-  = Hover
-      { contents :: MarkupContent 
-      , range :: UndefinedOr Range
-      }
+newtype Hover = Hover
+  { contents :: MarkupContent
+  , range :: UndefinedOr Range
+  }
 
-newtype Command
-  = Command { title :: String, command :: String, arguments :: Nullable (Array Foreign) }
+newtype Command = Command
+  { title :: String, command :: String, arguments :: Nullable (Array Foreign) }
 
 derive instance newtypeCommand :: Newtype Command _
 
-newtype CodeAction
-  = CodeAction
+newtype CodeAction = CodeAction
   { title :: String
   , kind :: CodeActionKind
   , isPreferred :: Boolean
@@ -274,57 +278,74 @@ foreign import data CodeActionResult :: Type
 codeActionResult :: Either CodeAction Command -> CodeActionResult
 codeActionResult = either unsafeCoerce unsafeCoerce
 
-newtype TextEdit
-  = TextEdit { range :: Range, newText :: String }
+newtype TextEdit = TextEdit { range :: Range, newText :: String }
 
 derive instance newtypeTextEdit :: Newtype TextEdit _
 
 instance eqTextEdit :: Eq TextEdit where
-  eq (TextEdit { range, newText }) (TextEdit { range: range', newText: newText' }) = range == range' && newText == newText'
+  eq
+    (TextEdit { range, newText })
+    (TextEdit { range: range', newText: newText' }) = range == range' && newText
+    == newText'
 
 instance showTextEdit :: Show TextEdit where
-  show (TextEdit { range, newText }) = ("TextEdit(" <> show range <> ", " <> show newText <> ")")
+  show (TextEdit { range, newText }) =
+    ("TextEdit(" <> show range <> ", " <> show newText <> ")")
 
-newtype WorkspaceEdit
-  = WorkspaceEdit
+newtype WorkspaceEdit = WorkspaceEdit
   { documentChanges :: Nullable (Array TextDocumentEdit)
   , changes :: Nullable (Object (Array TextEdit))
   }
 
 instance semigroupWorkspaceEdit :: Semigroup WorkspaceEdit where
-  append (WorkspaceEdit { documentChanges, changes }) (WorkspaceEdit { documentChanges: documentChanges', changes: changes' }) =
+  append
+    (WorkspaceEdit { documentChanges, changes })
+    (WorkspaceEdit { documentChanges: documentChanges', changes: changes' }) =
     WorkspaceEdit
       { documentChanges:
           toNullable
-            $ case isNothing (toMaybe documentChanges), isNothing (toMaybe documentChanges') of
+            $
+              case
+                isNothing (toMaybe documentChanges),
+                isNothing (toMaybe documentChanges')
+                of
                 true, true -> Nothing
                 _, _ ->
                   Just
                     $ map (foldl1 combine)
                     $ map toNonEmpty
                     $ groupBy (\d1 d2 -> docId d1 == docId d2)
-                        (fromNullableArray documentChanges <> fromNullableArray documentChanges')
+                        ( fromNullableArray documentChanges <> fromNullableArray
+                            documentChanges'
+                        )
       , changes:
           toNullable
             $ case isNothing (toMaybe changes), isNothing (toMaybe changes') of
                 true, true -> Nothing
                 _, _ ->
-                  Just $ Object.fromFoldableWith (<>) (goStrMap changes <> goStrMap changes')
+                  Just $ Object.fromFoldableWith (<>)
+                    (goStrMap changes <> goStrMap changes')
       }
     where
-    combine (TextDocumentEdit { textDocument, edits }) (TextDocumentEdit { edits: edits' }) =
+    combine
+      (TextDocumentEdit { textDocument, edits })
+      (TextDocumentEdit { edits: edits' }) =
       TextDocumentEdit { textDocument, edits: edits <> edits' }
     docId (TextDocumentEdit { textDocument }) = textDocument
+
     fromNullableArray :: forall a. Nullable (Array a) -> Array a
     fromNullableArray a = fromMaybe [] $ toMaybe a
+
     goStrMap :: forall a. Nullable (Object a) -> Array (Tuple String a)
     goStrMap a = Object.toUnfoldable $ fromMaybe Object.empty $ toMaybe a
 
 instance monoidWorkspaceEdit :: Monoid WorkspaceEdit where
-  mempty = WorkspaceEdit { documentChanges: toNullable Nothing, changes: toNullable Nothing }
+  mempty = WorkspaceEdit
+    { documentChanges: toNullable Nothing, changes: toNullable Nothing }
 
 -- | Create workspace edit, supporting both documentChanges and older changes property for v2 clients
-workspaceEdit :: Maybe ClientCapabilities -> Array TextDocumentEdit -> WorkspaceEdit
+workspaceEdit ::
+  Maybe ClientCapabilities -> Array TextDocumentEdit -> WorkspaceEdit
 workspaceEdit capabilities edits =
   WorkspaceEdit
     { documentChanges:
@@ -332,46 +353,54 @@ workspaceEdit capabilities edits =
           $ if useDocumentChanges then Just edits else Nothing
     , changes:
         toNullable
-          $ if useDocumentChanges then
+          $
+            if useDocumentChanges then
               Nothing
             else
               Just
                 $ Object.fromFoldable
-                $ map (\(h :| t) -> Tuple (uri h) (concat $ edit h : map edit t))
+                $ map
+                    (\(h :| t) -> Tuple (uri h) (concat $ edit h : map edit t))
                 $ map toNonEmpty
                 $ groupBy (\a b -> uri a == uri b)
                 $ sortWith uri edits
     }
   where
   useDocumentChanges = supportsDocumentChanges capabilities
-  uri (TextDocumentEdit { textDocument: OptionalVersionedTextDocumentIdentifier { uri: DocumentUri uri' } }) = uri'
+  uri
+    ( TextDocumentEdit
+        { textDocument: OptionalVersionedTextDocumentIdentifier
+            { uri: DocumentUri uri' }
+        }
+    ) = uri'
   edit (TextDocumentEdit { edits: edits' }) = edits'
 
 supportsDocumentChanges :: Maybe ClientCapabilities -> Boolean
 supportsDocumentChanges Nothing = false
-supportsDocumentChanges (Just { workspace }) = fromMaybe false $ toMaybe workspace >>= (_.workspaceEdit >>> toMaybe) >>= (_.documentChanges >>> toMaybe)
+supportsDocumentChanges (Just { workspace }) = fromMaybe false $
+  toMaybe workspace >>= (_.workspaceEdit >>> toMaybe) >>=
+    (_.documentChanges >>> toMaybe)
 
-newtype TextDocumentEdit
-  = TextDocumentEdit { textDocument :: OptionalVersionedTextDocumentIdentifier, edits :: Array TextEdit }
+newtype TextDocumentEdit = TextDocumentEdit
+  { textDocument :: OptionalVersionedTextDocumentIdentifier
+  , edits :: Array TextEdit
+  }
 
-newtype TextDocumentIdentifier
-  = TextDocumentIdentifier { uri :: DocumentUri }
+newtype TextDocumentIdentifier = TextDocumentIdentifier { uri :: DocumentUri }
 
 derive instance Newtype TextDocumentIdentifier _
 derive instance Eq TextDocumentIdentifier
 
-newtype OptionalVersionedTextDocumentIdentifier
-  = OptionalVersionedTextDocumentIdentifier { uri :: DocumentUri, version :: Nullable Number }
+newtype OptionalVersionedTextDocumentIdentifier =
+  OptionalVersionedTextDocumentIdentifier
+    { uri :: DocumentUri, version :: Nullable Number }
 
 derive instance Newtype OptionalVersionedTextDocumentIdentifier _
 derive instance Eq OptionalVersionedTextDocumentIdentifier
 
+type Settings = Foreign
 
-
-type Settings
-  = Foreign
-newtype FileChangeTypeCode
-  = FileChangeTypeCode Int
+newtype FileChangeTypeCode = FileChangeTypeCode Int
 
 data FileChangeType
   = CreatedChangeType
@@ -391,18 +420,16 @@ intToFileChangeType = case _ of
   3 -> Just DeletedChangeType
   _ -> Nothing
 
-fromFileChangeTypeCode ∷ FileChangeTypeCode -> Maybe FileChangeType
+fromFileChangeTypeCode :: FileChangeTypeCode -> Maybe FileChangeType
 fromFileChangeTypeCode = case _ of
   FileChangeTypeCode 1 -> Just CreatedChangeType
   FileChangeTypeCode 2 -> Just ChangedChangeType
   FileChangeTypeCode 3 -> Just DeletedChangeType
   _ -> Nothing
 
-newtype FileEvent
-  = FileEvent { uri :: DocumentUri, type :: FileChangeTypeCode }
+newtype FileEvent = FileEvent { uri :: DocumentUri, type :: FileChangeTypeCode }
 
-newtype FoldingRange
-  = FoldingRange
+newtype FoldingRange = FoldingRange
   { startLine :: Int
   , startCharacter :: Nullable Int
   , endLine :: Int
@@ -410,43 +437,59 @@ newtype FoldingRange
   , kind :: Nullable String -- | comment, imports, region
   }
 
-type ClientCapabilities
-  = { workspace :: Nullable WorkspaceClientCapabilities, textDocument :: Nullable TextDocumentClientCapabilities }
-type WorkspaceClientCapabilities
-  = { applyEdit :: Nullable Boolean, workspaceEdit :: Nullable WorkspaceEditClientCapabilities, codeLens :: Nullable CodeLensWorkspaceClientCapabilities }
+type ClientCapabilities =
+  { workspace :: Nullable WorkspaceClientCapabilities
+  , textDocument :: Nullable TextDocumentClientCapabilities
+  }
 
-type TextDocumentClientCapabilities
-  = { codeAction :: Nullable CodeActionClientCapabilities
-    , definition :: Nullable DefinitionClientCapabilities
-    , codeLens :: Nullable CodeLensClientCapabilities
-    }
-type DefinitionClientCapabilities
-  = { linkSupport :: Nullable Boolean }
-type CodeActionClientCapabilities
-  = { codeActionLiteralSupport :: Nullable { codeActionKind :: { valueSet :: Array CodeActionKind } }, isPreferredSupport :: Nullable Boolean }
-type CodeLensClientCapabilities
-  = { dynamicRegistration :: Nullable Boolean }
+type WorkspaceClientCapabilities =
+  { applyEdit :: Nullable Boolean
+  , workspaceEdit :: Nullable WorkspaceEditClientCapabilities
+  , codeLens :: Nullable CodeLensWorkspaceClientCapabilities
+  }
 
-type CodeLensWorkspaceClientCapabilities
-  = { refreshSupport :: Nullable Boolean }
+type TextDocumentClientCapabilities =
+  { codeAction :: Nullable CodeActionClientCapabilities
+  , definition :: Nullable DefinitionClientCapabilities
+  , codeLens :: Nullable CodeLensClientCapabilities
+  }
 
-newtype CodeActionKind
-  = CodeActionKind String
+type DefinitionClientCapabilities = { linkSupport :: Nullable Boolean }
+
+type CodeActionClientCapabilities =
+  { codeActionLiteralSupport ::
+      Nullable { codeActionKind :: { valueSet :: Array CodeActionKind } }
+  , isPreferredSupport :: Nullable Boolean
+  }
+
+type CodeLensClientCapabilities = { dynamicRegistration :: Nullable Boolean }
+
+type CodeLensWorkspaceClientCapabilities =
+  { refreshSupport :: Nullable Boolean }
+
+newtype CodeActionKind = CodeActionKind String
+
 instance showCodeActionKind :: Show CodeActionKind where
   show (CodeActionKind s) = "CodeActionKind " <> s
 
 codeActionEmpty :: CodeActionKind
 codeActionEmpty = CodeActionKind ""
+
 codeActionQuickFix :: CodeActionKind
 codeActionQuickFix = CodeActionKind "quickfix"
+
 codeActionRefactor :: CodeActionKind
 codeActionRefactor = CodeActionKind "refactor"
+
 codeActionRefactorExtract :: CodeActionKind
 codeActionRefactorExtract = CodeActionKind "refactor.extract"
+
 codeActionRefactorInline :: CodeActionKind
 codeActionRefactorInline = CodeActionKind "refactor.inline"
+
 codeActionRefactorRewrite :: CodeActionKind
 codeActionRefactorRewrite = CodeActionKind "refactor.rewrite"
+
 codeActionSource :: CodeActionKind
 codeActionSource = CodeActionKind "source"
 
@@ -458,5 +501,4 @@ codeActionSourceOrganizeImports :: CodeActionKind
 codeActionSourceOrganizeImports = CodeActionKind "source.organizeImports"
 
 -- https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspaceEditClientCapabilities
-type WorkspaceEditClientCapabilities
-  = { documentChanges :: Nullable Boolean }
+type WorkspaceEditClientCapabilities = { documentChanges :: Nullable Boolean }

--- a/src/LanguageServer/Protocol/Window.purs
+++ b/src/LanguageServer/Protocol/Window.purs
@@ -15,6 +15,7 @@ module LanguageServer.Protocol.Window
   ) where
 
 import Prelude
+
 import Control.Promise (Promise)
 import Control.Promise as Promise
 import Data.Maybe (Maybe)
@@ -23,42 +24,69 @@ import Effect (Effect)
 import Effect.Aff (Aff)
 import LanguageServer.Protocol.Types (Connection)
 
-type MessageAction
-  = { title :: String }
+type MessageAction = { title :: String }
 
 foreign import showError :: Connection -> String -> Effect Unit
-foreign import showErrorWithActionsImpl :: Connection -> String -> Array MessageAction -> Effect (Promise (Nullable MessageAction))
+foreign import showErrorWithActionsImpl ::
+  Connection ->
+  String ->
+  Array MessageAction ->
+  Effect (Promise (Nullable MessageAction))
 
 convertMessageAction :: Nullable MessageAction -> Maybe String
 convertMessageAction act = _.title <$> toMaybe act
 
-showErrorWithActions :: Connection -> String -> Array String -> Aff (Maybe String)
+showErrorWithActions ::
+  Connection -> String -> Array String -> Aff (Maybe String)
 showErrorWithActions conn msg acts =
-  convertMessageAction <$> (Promise.toAffE $ showErrorWithActionsImpl conn msg (map (\title -> { title }) acts))
+  convertMessageAction <$>
+    ( Promise.toAffE $ showErrorWithActionsImpl conn msg
+        (map (\title -> { title }) acts)
+    )
 
 foreign import showWarning :: Connection -> String -> Effect Unit
-foreign import showWarningWithActionsImpl :: Connection -> String -> Array MessageAction -> Effect (Promise (Nullable MessageAction))
+foreign import showWarningWithActionsImpl ::
+  Connection ->
+  String ->
+  Array MessageAction ->
+  Effect (Promise (Nullable MessageAction))
 
-showWarningWithActions :: Connection -> String -> Array String -> Aff (Maybe String)
+showWarningWithActions ::
+  Connection -> String -> Array String -> Aff (Maybe String)
 showWarningWithActions conn msg acts =
-  convertMessageAction <$> (Promise.toAffE $ showWarningWithActionsImpl conn msg (map (\title -> { title }) acts))
+  convertMessageAction <$>
+    ( Promise.toAffE $ showWarningWithActionsImpl conn msg
+        (map (\title -> { title }) acts)
+    )
 
 foreign import showInformation :: Connection -> String -> Effect Unit
-foreign import showInformationWithActionsImpl :: Connection -> String -> Array MessageAction -> Effect (Promise (Nullable MessageAction))
+foreign import showInformationWithActionsImpl ::
+  Connection ->
+  String ->
+  Array MessageAction ->
+  Effect (Promise (Nullable MessageAction))
 
-showInformationWithActions :: Connection -> String -> Array String -> Aff (Maybe String)
+showInformationWithActions ::
+  Connection -> String -> Array String -> Aff (Maybe String)
 showInformationWithActions conn msg acts =
-  convertMessageAction <$> (Promise.toAffE $ showInformationWithActionsImpl conn msg (map (\title -> { title }) acts))
+  convertMessageAction <$>
+    ( Promise.toAffE $ showInformationWithActionsImpl conn msg
+        (map (\title -> { title }) acts)
+    )
 
 foreign import data WorkDoneProgressReporter :: Type
 
 foreign import workDone :: WorkDoneProgressReporter -> Effect Unit
-foreign import workBegin :: WorkDoneProgressReporter -> { title :: String } -> Effect Unit
+foreign import workBegin ::
+  WorkDoneProgressReporter -> { title :: String } -> Effect Unit
+
 foreign import report :: WorkDoneProgressReporter -> Number -> Effect Unit
 foreign import reportMsg :: WorkDoneProgressReporter -> String -> Effect Unit
-foreign import report2 :: WorkDoneProgressReporter -> Number -> String -> Effect Unit
+foreign import report2 ::
+  WorkDoneProgressReporter -> Number -> String -> Effect Unit
 
-foreign import createWorkDoneProgressImpl :: Connection -> Effect (Promise WorkDoneProgressReporter)
+foreign import createWorkDoneProgressImpl ::
+  Connection -> Effect (Promise WorkDoneProgressReporter)
 
 createWorkDoneProgress :: Connection -> Aff WorkDoneProgressReporter
 createWorkDoneProgress conn = Promise.toAffE $ createWorkDoneProgressImpl conn

--- a/src/LanguageServer/Protocol/Window.ts
+++ b/src/LanguageServer/Protocol/Window.ts
@@ -1,7 +1,7 @@
 import {
   Connection,
   MessageActionItem,
-  WorkDoneProgressServerReporter
+  WorkDoneProgressServerReporter,
 } from "vscode-languageserver/node";
 
 export const showError = (conn: Connection) => (s: string) => () =>

--- a/src/LanguageServer/Protocol/Workspace.js
+++ b/src/LanguageServer/Protocol/Workspace.js
@@ -1,4 +1,4 @@
-import { CodeLensRefreshRequest } from "vscode-languageserver/node";
+import { CodeLensRefreshRequest, } from "vscode-languageserver/node";
 export var codeLensRefresh = function (conn) { return function () {
     return conn.sendRequest(CodeLensRefreshRequest.type);
 }; };

--- a/src/LanguageServer/Protocol/Workspace.ts
+++ b/src/LanguageServer/Protocol/Workspace.ts
@@ -1,7 +1,7 @@
 import {
   CodeLensRefreshRequest,
   Connection,
-  MessageActionItem
+  MessageActionItem,
 } from "vscode-languageserver/node";
 
 export const codeLensRefresh = (conn: Connection) => () =>

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,16 +1,16 @@
-module Test.Main
-where
+module Test.Main where
 
 import Prelude
+
 import Data.Array (concat)
 import Data.Maybe (Maybe(..), fromMaybe)
 import Data.Nullable (null, toMaybe)
 import Data.Nullable as Nullable
 import Effect (Effect)
 import IdePurescript.Tokens (identifierAtPoint)
-import LanguageServer.IdePurescript.FileTypes (RelevantFileType(..), uriToRelevantFileType, jsUriToMayPsUri)
+import LanguageServer.IdePurescript.FileTypes (RelevantFileType(..), jsUriToMayPsUri, uriToRelevantFileType)
 import LanguageServer.Protocol.Text (makeMinimalWorkspaceEdit)
-import LanguageServer.Protocol.Types (DocumentUri(..), Position(..), Range(..), TextDocumentEdit(..), TextEdit(..), WorkspaceEdit(..), ClientCapabilities)
+import LanguageServer.Protocol.Types (ClientCapabilities, DocumentUri(..), Position(..), Range(..), TextDocumentEdit(..), TextEdit(..), WorkspaceEdit(..))
 import Test.Unit (suite, test)
 import Test.Unit.Assert as Assert
 import Test.Unit.Main (runTest)
@@ -37,7 +37,8 @@ capabilities =
   { workspace:
       Nullable.notNull
         { applyEdit: Nullable.notNull true
-        , workspaceEdit: Nullable.notNull { documentChanges: Nullable.notNull true }
+        , workspaceEdit: Nullable.notNull
+            { documentChanges: Nullable.notNull true }
         , codeLens: Nullable.null
         }
   , textDocument: null
@@ -91,17 +92,18 @@ main =
         Assert.equal (result <#> _.word) (Just """/\""")
         Assert.equal (result <#> _.range) (Just { left: 3, right: 5 })
     suite "file handling" do
-          test "Determine file type" do
-            let f x y = Assert.equal x $ uriToRelevantFileType $ DocumentUri y
-            f PureScriptFile "foo/bar/baz.purs"
-            f PureScriptFile "./foo.purs"
-            f PureScriptFile "foo.purs"
-            f JavaScriptFile "foo.js"
-            f UnsupportedFile "foo.xyz"
-          test "convert js uri to ps uri" do
-            let mmUnwrap (DocumentUri x) = x
-            let f x y = Assert.equal (Just x) $ mmUnwrap <$> jsUriToMayPsUri (DocumentUri y)
-            f "foo/bar/baz.purs" "foo/bar/baz.js"
-            f "./foo.purs" "./foo.js"
-            f "foo.purs" "foo.js"
-    
+      test "Determine file type" do
+        let f x y = Assert.equal x $ uriToRelevantFileType $ DocumentUri y
+        f PureScriptFile "foo/bar/baz.purs"
+        f PureScriptFile "./foo.purs"
+        f PureScriptFile "foo.purs"
+        f JavaScriptFile "foo.js"
+        f UnsupportedFile "foo.xyz"
+      test "convert js uri to ps uri" do
+        let mmUnwrap (DocumentUri x) = x
+        let
+          f x y = Assert.equal (Just x) $ mmUnwrap <$> jsUriToMayPsUri ( DocumentUri y
+            )
+        f "foo/bar/baz.purs" "foo/bar/baz.js"
+        f "./foo.purs" "./foo.js"
+        f "foo.purs" "foo.js"


### PR DESCRIPTION
As `purs-tidy` kind of standard de-facto and to make LS codebase formatting more standardized and clean this PR formats all purs sources with the following settings:

```json
{
  "importSort": "ide",
  "importWrap": "source",
  "indent": 2,
  "operatorsFile": null,
  "ribbon": 5,
  "typeArrowPlacement": "last",
  "unicode": "never",
  "width": 80
}
```

This PR also includes a couple of small cleanup changes in logging, removing excessive output on the server start (protocol settings, PATH env value) because they just clutter the output.