### PR TITLE
Rename refactoring capablities v1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,8 @@
       "version": "0.17.1",
       "license": "MIT",
       "dependencies": {
-        "purs-tidy": "^0.9.2",
         "shell-quote": "^1.7.2",
-        "uuid": "^3.3.2",
+        "uuid": "^9.0.0",
         "vscode-jsonrpc": "^8.0.0-next.2",
         "vscode-languageserver": "^8.0.0-next.2",
         "vscode-languageserver-textdocument": "^1.0.1",
@@ -22,22 +21,16 @@
         "purescript-language-server": "server.js"
       },
       "devDependencies": {
-        "@rowtype-yoga/prettier-plugin-purescript": "^1.11.2",
         "@types/node": "^16.9.6",
         "esbuild": "^0.13.15",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.4.1",
+        "purs-tidy": "^0.9.2",
         "typescript": "^4.8.0-dev.20220601"
       },
       "engines": {
         "node": ">=14"
       }
-    },
-    "node_modules/@rowtype-yoga/prettier-plugin-purescript": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@rowtype-yoga/prettier-plugin-purescript/-/prettier-plugin-purescript-1.11.2.tgz",
-      "integrity": "sha512-9G66e0cF+OB5wzX4SZKV8/gsAOkxJsuIUXeiNrzstEbc/a7aI4LT+ho+Tkz3JBkNCtvz9Z5GPL50WLaq1XGLPQ==",
-      "dev": true
     },
     "node_modules/@types/node": {
       "version": "16.11.10",
@@ -969,6 +962,7 @@
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/purs-tidy/-/purs-tidy-0.9.2.tgz",
       "integrity": "sha512-v7Do4E9Tx2OqEhJXKl5tJxjRcmDilMObm0+XgYphpbMelkUQ+CfhtetIk294byhaL18OpEHqmO6BUkyNCBJDpQ==",
+      "dev": true,
       "bin": {
         "purs-tidy": "bin/index.js"
       }
@@ -1174,12 +1168,11 @@
       }
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-license": {
@@ -1267,12 +1260,6 @@
     }
   },
   "dependencies": {
-    "@rowtype-yoga/prettier-plugin-purescript": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@rowtype-yoga/prettier-plugin-purescript/-/prettier-plugin-purescript-1.11.2.tgz",
-      "integrity": "sha512-9G66e0cF+OB5wzX4SZKV8/gsAOkxJsuIUXeiNrzstEbc/a7aI4LT+ho+Tkz3JBkNCtvz9Z5GPL50WLaq1XGLPQ==",
-      "dev": true
-    },
     "@types/node": {
       "version": "16.11.10",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.10.tgz",
@@ -1919,7 +1906,8 @@
     "purs-tidy": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/purs-tidy/-/purs-tidy-0.9.2.tgz",
-      "integrity": "sha512-v7Do4E9Tx2OqEhJXKl5tJxjRcmDilMObm0+XgYphpbMelkUQ+CfhtetIk294byhaL18OpEHqmO6BUkyNCBJDpQ=="
+      "integrity": "sha512-v7Do4E9Tx2OqEhJXKl5tJxjRcmDilMObm0+XgYphpbMelkUQ+CfhtetIk294byhaL18OpEHqmO6BUkyNCBJDpQ==",
+      "dev": true
     },
     "read-pkg": {
       "version": "3.0.0",
@@ -2076,9 +2064,9 @@
       }
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   ],
   "dependencies": {
     "shell-quote": "^1.7.2",
-    "uuid": "^3.3.2",
+    "uuid": "^9.0.0",
     "vscode-jsonrpc": "^8.0.0-next.2",
     "vscode-languageserver": "^8.0.0-next.2",
     "vscode-languageserver-textdocument": "^1.0.1",

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,6 +1,5 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.15.2-20220706/packages.dhall
-        sha256:7a24ebdbacb2bfa27b2fc6ce3da96f048093d64e54369965a2a7b5d9892b6031
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.2-20220706/packages.dhall sha256:7a24ebdbacb2bfa27b2fc6ce3da96f048093d64e54369965a2a7b5d9892b6031
 
 in  upstream
   with uuid =
@@ -22,28 +21,49 @@ in  upstream
         "https://github.com/working-group-purescript-es/purescript-foreign-generic.git"
     , version = "53410dd57e9b350d6c233f48f7aa46317c4faa21"
     }
-
   with untagged-union =
     { dependencies =
       [ "assert"
-  , "console"
-  , "effect"
-  , "either"
-  , "foreign"
-  , "foreign-object"
-  , "literals"
-  , "maybe"
-  , "newtype"
-  , "prelude"
-  , "tuples"
-  , "unsafe-coerce"
+      , "console"
+      , "effect"
+      , "either"
+      , "foreign"
+      , "foreign-object"
+      , "literals"
+      , "maybe"
+      , "newtype"
+      , "prelude"
+      , "tuples"
+      , "unsafe-coerce"
       ]
-    , repo =
-        "https://github.com/rowtype-yoga/purescript-untagged-union.git"
+    , repo = "https://github.com/rowtype-yoga/purescript-untagged-union.git"
     , version = "ed8262a966e15e751322c327e2759a9b9c0ef3f3"
     }
-
   with literals.repo = "https://github.com/ilyakooo0/purescript-literals.git"
   with literals.version = "6875fb28026595cfb780318305a77e79b098bb01"
-  
+
   with psc-ide.version = "0f16603b3336340cbdbde197671cb96ff969a5f8"
+  -- purescript-language-cst-parser v0.12.1 with bugfixes is not yet in the package set.
+  with language-cst-parser =
+    { dependencies =
+      [ "arrays"
+      , "console"
+      , "const"
+      , "debug"
+      , "effect"
+      , "either"
+      , "filterable"
+      , "foldable-traversable"
+      , "free"
+      , "functors"
+      , "maybe"
+      , "numbers"
+      , "psci-support"
+      , "strings"
+      , "transformers"
+      , "tuples"
+      , "typelevel-prelude"
+      ]
+    , repo = "https://github.com/natefaubion/purescript-language-cst-parser.git"
+    , version = "v0.12.1"
+    }

--- a/spago.dhall
+++ b/spago.dhall
@@ -50,6 +50,7 @@ You can edit this file as you like.
   , "psc-ide"
   , "psci-support"
   , "refs"
+  , "spec"
   , "strings"
   , "stringutils"
   , "test-unit"

--- a/src/IdePurescript/Modules.js
+++ b/src/IdePurescript/Modules.js
@@ -1,3 +1,5 @@
+import * as os from "os"
+
 export function tmpDir() {
-  return require("os").tmpdir();
+  return os.tmpdir();
 }

--- a/src/IdePurescript/Modules.purs
+++ b/src/IdePurescript/Modules.purs
@@ -124,9 +124,10 @@ getUnqualActiveModules state ident = getModules include state
   where
   include (Module { qualifier: Just _ }) = false
   include (Module { importType: Explicit idents }) =
-    -- idents array doesn't contain imports of constructors, something like:
-    -- (A), (A,B) or (..)
-    maybe false (_ `elem` idents) ident
+    -- idents array contains operators inside parentheses: `(/\)`. Note: it
+    -- doesn't contain imports of constructors, something like: (A), (A,B) or
+    -- (..)
+    maybe false (\x -> x `elem` idents || ("(" <> x <> ")") `elem` idents) ident
   include (Module { importType: Implicit }) = true
   include (Module { importType: Hiding idents }) =
     maybe true (_ `notElem` idents) ident

--- a/src/IdePurescript/Modules.purs
+++ b/src/IdePurescript/Modules.purs
@@ -7,6 +7,7 @@ module IdePurescript.Modules
   , getModulesForFile
   , getModulesForFileTemp
   , getUnqualActiveModules
+  , getAllUnqualActiveModules
   , getAllActiveModules
   , getQualModule
   , getModuleFromUnknownQualifier
@@ -116,17 +117,26 @@ mkImplicit :: String -> Module
 mkImplicit m = Module
   { qualifier: Nothing, importType: Implicit, moduleName: m }
 
+-- Returns unqualified modules that can possibly import the ident. If ident is
+-- Nothing it returns only implicit imports.
 getUnqualActiveModules :: State -> Maybe String -> Array String
 getUnqualActiveModules state ident = getModules include state
   where
   include (Module { qualifier: Just _ }) = false
-  include (Module { importType: Explicit idents }) = maybe false
-    (\x -> x `elem` idents || ("(" <> x <> ")") `elem` idents)
-    ident
+  include (Module { importType: Explicit idents }) =
+    -- idents array doesn't contain imports of constructors, something like:
+    -- (A), (A,B) or (..)
+    maybe false (_ `elem` idents) ident
   include (Module { importType: Implicit }) = true
-  include (Module { importType: Hiding idents }) = maybe true
-    (_ `notElem` idents)
-    ident
+  include (Module { importType: Hiding idents }) =
+    maybe true (_ `notElem` idents) ident
+
+-- Returns all unqualified modules that can possibly, explicit and implicit.
+getAllUnqualActiveModules :: State -> Array String
+getAllUnqualActiveModules state = getModules include state
+  where
+  include (Module { qualifier: Just _ }) = false
+  include (_) = true
 
 getAllActiveModules :: State -> Array String
 getAllActiveModules = getModules (const true)

--- a/src/IdePurescript/PscIde.purs
+++ b/src/IdePurescript/PscIde.purs
@@ -10,13 +10,13 @@ module IdePurescript.PscIde
   , getModuleInfo
   , getPursuitCompletion
   , getPursuitModuleCompletion
-  , getType
+  -- , getType
   , getTypeInfo
+  , getTypeInfos
   , getTypeInfoWithImportFilter
   , loadDeps
   , typesInModule
-  )
-  where
+  ) where
 
 import Prelude
 
@@ -75,6 +75,20 @@ type TypeResult =
   , position :: Maybe TypePosition
   }
 
+getTypeInfos ::
+  Int ->
+  String ->
+  Maybe String ->
+  Maybe String ->
+  Array String ->
+  (String -> Array String) ->
+  Aff (Array C.TypeInfo)
+getTypeInfos port text currentModule modulePrefix unqualModules getQualifiedModule =
+  result identity $ P.type' port text moduleFilters currentModule
+  where
+  moduleFilters =
+    [ C.ModuleFilter $ maybe unqualModules getQualifiedModule modulePrefix ]
+
 getTypeInfo ::
   Int ->
   String ->
@@ -83,13 +97,7 @@ getTypeInfo ::
   Array String ->
   (String -> Array String) ->
   Aff (Maybe C.TypeInfo)
-getTypeInfo
-  port
-  text
-  currentModule
-  modulePrefix
-  unqualModules
-  getQualifiedModule =
+getTypeInfo port text currentModule modulePrefix unqualModules getQualifiedModule =
   result head $ P.type' port text moduleFilters currentModule
   where
   moduleFilters =
@@ -109,7 +117,7 @@ getTypeInfoWithImportFilter port text currentModule qualifier importLines =
   moduleFilters = [ C.DependencyFilter qualifier moduleText ]
   moduleText = String.joinWith "\n" $
     "module RequestModule where" :
-    importLines
+      importLines
 
 getModuleInfo :: Int -> String -> Aff (Maybe C.TypeInfo)
 getModuleInfo port text =
@@ -117,20 +125,20 @@ getModuleInfo port text =
   where
   filters = [ C.DeclarationFilter [ DeclModule ] ]
 
-getType ::
-  Int ->
-  String ->
-  Maybe String ->
-  Maybe String ->
-  Array String ->
-  (String -> Array String) ->
-  Aff String
-getType port text currentModule modulePrefix unqualModules getQualifiedModule =
-  maybe "" getType' <$> getTypeInfo port text currentModule modulePrefix
-    unqualModules
-    getQualifiedModule
-  where
-  getType' (C.TypeInfo { type' }) = type'
+-- getType ::
+--   Int ->
+--   String ->
+--   Maybe String ->
+--   Maybe String ->
+--   Array String ->
+--   (String -> Array String) ->
+--   Aff String
+-- getType port text currentModule modulePrefix unqualModules getQualifiedModule =
+--   maybe "" getType' <$> getTypeInfo port text currentModule modulePrefix
+--     unqualModules
+--     getQualifiedModule
+--   where
+--   getType' (C.TypeInfo { type' }) = type'
 
 type CompletionResult =
   { type :: String, identifier :: String, module :: String }

--- a/src/IdePurescript/Tokens.purs
+++ b/src/IdePurescript/Tokens.purs
@@ -28,10 +28,11 @@ moduleRegex = regex (modulePrefix <> "?" <> identPart <> "?$") noFlags
   modulePrefix :: String
   modulePrefix = "(?:^|[^A-Za-z_.])(?:" <> modulePart <> """\.)"""
 
-identifierAtPoint ::
-  String ->
-  Int ->
-  Maybe { word :: String, range :: WordRange, qualifier :: Maybe String }
+type TokenInfo = { word :: String, range :: WordRange, qualifier :: Maybe String }
+
+-- | Finds identifier token at given position (column number) of the text
+-- | string.
+identifierAtPoint :: String -> Int -> Maybe TokenInfo
 identifierAtPoint line column =
   go $ TokenStream.step $ CST.Lexer.lex line
   where

--- a/src/LanguageServer/IdePurescript/Rename.purs
+++ b/src/LanguageServer/IdePurescript/Rename.purs
@@ -1,0 +1,651 @@
+module LanguageServer.IdePurescript.Rename
+  ( prepareRename
+  , renameIdentifier
+  -- below methods and types exported for tests
+  , getTypeInfoWithUsages
+  , getTextAtRangeInLines
+  , getTextEdits
+  , DocToEdit
+  , TextEditsMap
+  ) where
+
+import Prelude
+
+import Control.Monad.Error.Class (throwError)
+import Data.Array as Array
+import Data.Either (Either(..), hush)
+import Data.Map (Map)
+import Data.Map as Map
+import Data.Maybe (Maybe(..), fromMaybe, maybe)
+import Data.Newtype (over, un)
+import Data.Nullable (Nullable)
+import Data.Nullable as Nullable
+import Data.String (Pattern(..))
+import Data.String as String
+import Data.String.Regex (regex, search, test) as Regex
+import Data.String.Regex.Flags (ignoreCase, noFlags) as Regex
+import Data.Tuple.Nested (type (/\), (/\))
+import Effect.Aff (Aff, error)
+import Effect.Class (liftEffect)
+import IdePurescript.Modules (getQualModule, getUnqualActiveModules)
+import IdePurescript.Modules as Modules
+import IdePurescript.PscIdeServer (Port)
+import IdePurescript.Tokens (identifierAtPoint, startsWithCapitalLetter)
+import LanguageServer.IdePurescript.Rename.CST (getDeclSignatureName, getExportedRanges, getImportedRanges)
+import LanguageServer.IdePurescript.Types (ServerState(..))
+import LanguageServer.IdePurescript.Util (maybeParseResult)
+import LanguageServer.Protocol.DocumentStore (getDocument)
+import LanguageServer.Protocol.Handlers (PrepareRenameParams, RenameParams, TextDocumentPositionParams)
+import LanguageServer.Protocol.Text (makeMultiWorkspaceEdit)
+import LanguageServer.Protocol.TextDocument (getText, getTextAtRange, getVersion)
+import LanguageServer.Protocol.Types (DocumentStore, DocumentUri, Position(..), Range(..), Settings, TextDocumentIdentifier(..), WorkspaceEdit(..))
+import LanguageServer.Protocol.Uri (filenameToUri, uriToFilename)
+import Node.Encoding (Encoding(..))
+import Node.FS.Aff as FS
+import PscIde as P
+import PscIde.Command (DeclarationType(..), Namespace(..), TypeInfo(..), TypePosition(..))
+import PscIde.Command as C
+import PureScript.CST (RecoveredParserResult, parseModule)
+import PureScript.CST.Types (Module, ModuleName(..))
+
+-- | Handler for prepare rename operation.
+prepareRename ::
+  DocumentStore ->
+  Settings ->
+  ServerState ->
+  PrepareRenameParams ->
+  Aff (Nullable Range)
+prepareRename docs settings state ({ textDocument, position }) = do
+  identInfo <- getIdentInfo docs settings state { textDocument, position }
+  pure $ Nullable.toNullable $ _.range <$> identInfo
+
+-- | Handler for rename operation.
+renameIdentifier ::
+  DocumentStore ->
+  Settings ->
+  ServerState ->
+  RenameParams ->
+  Aff (WorkspaceEdit)
+renameIdentifier docs settings state ({ textDocument, position, newName }) = do
+  identInfo <- getIdentInfo docs settings state { textDocument, position }
+  case identInfo of
+    Just ({ word, found: Right { typeInfo, usages } }) -> do
+      docsToEdit <- getDocsToEdit typeInfo usages
+      liftEffect $ do
+        let usgEdits = getTextEdits typeInfo usages docsToEdit newName word
+        pure
+          $ makeMultiWorkspaceEdit clientCapabilities (toMultiEdits usgEdits)
+    -- Means that we deal with a local identifier.
+    -- Not implemented.
+    Just ({ found: Left { } }) -> do
+      pure wsEditEmpty
+
+    Nothing -> do
+      pure wsEditEmpty
+  where
+  wsEditEmpty = WorkspaceEdit
+    { documentChanges: Nullable.null
+    , changes: Nullable.null
+    }
+
+  { clientCapabilities } = un ServerState $ state
+
+  toMultiEdits m =
+    Map.toUnfoldable m
+      <#> (\((uri /\ version) /\ edits) -> { uri, version, edits })
+
+  getDocsToEdit (TypeInfo ti) usages =
+    Array.foldM goFile Map.empty files
+    where
+    getName (TypePosition { name }) = name
+    files = Array.nub
+      $ (usages <#> getName)
+          <> maybe [] Array.singleton (ti.definedAt <#> getName)
+
+  goFile dcs path = do
+    uri <- liftEffect $ filenameToUri path
+    mbDoc <- liftEffect $ getDocument docs uri
+    docText /\ version <-
+      case (Nullable.toMaybe mbDoc) of
+        -- For docs that were not yet opened in the editor we read the file
+        -- from disk to search its content.
+        --
+        -- Alternatively may try this:
+        -- https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_showDocument
+        Nothing -> do
+          docText <- FS.readTextFile (UTF8) path
+          pure (docText /\ Nothing)
+        Just doc -> liftEffect $ do
+          version <- getVersion doc
+          docText <- getText doc
+          pure (docText /\ Just version)
+
+    pure $ Map.insert path
+      { uri
+      , docTextAtRange:
+          getTextAtRangeInLines (splitLines docText)
+      , version
+      , parsed: parseModule docText
+      }
+      dcs
+
+type DocToEdit =
+  { docTextAtRange :: Range -> String
+  , uri :: DocumentUri
+  , version :: Maybe Number
+  , parsed :: RecoveredParserResult Module
+  }
+
+type TextEditsMap =
+  Map (DocumentUri /\ (Maybe Number))
+    (Array { newText :: String, range :: Range })
+
+-- | Maps found typeInfo and usages to plain text edits.
+getTextEdits ::
+  TypeInfo ->
+  Array (TypePosition) ->
+  Map String DocToEdit ->
+  String ->
+  String ->
+  TextEditsMap
+getTextEdits typeInfo usages docsToEdit newText oldName =
+  -- We use Maybe
+  ( Just Map.empty
+      # addUsagesEdits
+      # addTypeDefEdit
+      # addImportsEdits
+  )
+    # fromMaybe Map.empty
+    -- We remove possible ranges duplication due to combination of purs ide
+    -- usage results and local logic based on CST parsing.
+    # removeDups
+  where
+  removeDups = map Array.nub
+
+  (TypeInfo ty) = typeInfo
+  moduleDefinedIn = ModuleName ty.module'
+  addUsagesEdits edits =
+    Array.foldl
+      ( \editsMap tp@(TypePosition { name }) ->
+          case Map.lookup name docsToEdit of
+            Nothing ->
+              editsMap
+            Just { docTextAtRange, uri, version } ->
+              let
+                useRange = rangeFromTypePos $ tp
+                rangeText = docTextAtRange useRange
+                -- Get qualifier index.
+                qualIdx = maybe 0 ((+) 1) $ String.indexOf (Pattern ".") rangeText
+
+                -- Make new text from old because found range may contain
+                -- other symbols beside the name (in case of constructor unwrapping).
+
+                -- This is a bit tricky case and workaround. Purs ide returns
+                -- for usage of types/constructors in imports whole type with
+                -- ctors span: Name(A, Name), where the name of type can be
+                -- the same as ctor name. So is we are looking for constructor
+                -- replace it with "_ame(A, Name)", to find correct position.
+                handleCtorImport t
+                  | isCtor, Just idx <- String.lastIndexOf (Pattern oldName) t, idx > 0 =
+                      ((<>) "_" <<< String.drop 1) t
+                handleCtorImport t = t
+
+                mbRange = useRange
+                  # rangeShiftLeft qualIdx
+                  # findWordInRange (Pattern oldName)
+                      (rangeText # String.drop qualIdx # handleCtorImport)
+                addEdit' range = addEdit (uri /\ version) { range, newText }
+
+              in
+                editsMap # maybe cancelEdit addEdit' mbRange
+      )
+      edits
+      usages
+
+  -- Adds defined info position and exports
+  addTypeDefEdit edits =
+    case getDefined typeInfo of
+      Nothing ->
+        edits
+      Just (tp /\ { docTextAtRange, version, uri, parsed }) ->
+        let
+          defRange = rangeFromTypePos tp
+          addEdit' range = addEdit (uri /\ version) { range, newText }
+          fixRange range =
+            let
+              rangeText = docTextAtRange range
+              mbRange = findWordInRange (Pattern oldName) rangeText range
+            in
+              maybe cancelEdit addEdit' mbRange
+
+        in
+          edits
+            # fixRange defRange
+            -- Add export and declaration edit. Actual if purs ide does not return
+            -- positions in exports. CST parsed results to may too provide ranges
+            -- that should be fixed.
+            # maybeParseResult identity
+                ( \m ->
+                    ( case Array.head $ getExportedRanges m isType oldName of
+                        Just range -> do
+                          fixRange range
+                        Nothing ->
+                          identity
+                    )
+                      -- Add declaration signature.
+                      # (<<<)
+                          case getDeclSignatureName m isType oldName of
+                            Just range ->
+                              addEdit' range
+                            Nothing ->
+                              identity
+                )
+                parsed
+
+    where
+    getDefined (TypeInfo { definedAt }) =
+      definedAt
+        >>= \tp@(TypePosition { name }) ->
+          Map.lookup name docsToEdit
+            <#> \doc -> tp /\ doc
+
+  -- Finds usages parsed module in imports. Actual if purs ide does not return
+  -- positions in imports. CST parsed results to may too provide ranges that
+  -- should be fixed.
+  addImportsEdits edits =
+    Array.foldl
+      ( \editsMap fileName ->
+          case Map.lookup fileName docsToEdit of
+            Just { uri, version, parsed, docTextAtRange } ->
+              let
+                addEdit' range = addEdit (uri /\ version) { range, newText }
+                fixRange range =
+                  let
+                    rangeText = docTextAtRange range
+                    mbRange = findWordInRange (Pattern oldName) rangeText range
+                  in
+                    maybe cancelEdit addEdit' mbRange
+              in
+                editsMap #
+                  ( maybeParseResult identity
+                      ( \m ->
+                          case
+                            Array.head $ getImportedRanges m isType oldName moduleDefinedIn
+                            of
+                            Just range ->
+                              fixRange range
+                            Nothing ->
+                              identity
+                      )
+                      parsed
+                  )
+            Nothing ->
+              editsMap
+      )
+      edits
+      files
+    where
+    (TypeInfo ti) = typeInfo
+    getName (TypePosition { name }) = name
+    defFileName = ti.definedAt <#> getName
+    -- All files to edit without the file with type definition.
+    files =
+      ( maybe identity (\defFile -> Array.filter (\name -> name /= defFile))
+          defFileName
+      )
+        (Array.nub $ usages <#> getName)
+
+  isType = isNSType $ typeInfoToNs typeInfo
+  isCtor = startsWithCapitalLetter oldName && not isType
+
+  toRangePos { line, column } =
+    Position { line: line - 1, character: column - 1 }
+
+  rangeFromTypePos (TypePosition { start, end }) =
+    Range
+      { start: toRangePos start
+      , end: toRangePos end
+      }
+
+  addEdit key edit m =
+    m <#> Map.alter (Just <<< maybe [ edit ] (Array.cons edit)) key
+
+  cancelEdit = const Nothing
+
+  rangeShiftLeft charNum (Range ({ start: Position p, end })) =
+    Range
+      ( { start: Position { line: p.line, character: p.character + charNum }
+        , end
+        }
+      )
+
+--| Uses purs ide to find information about definition and usages of rename target given its
+-- symbolic name and its type position.
+--
+-- TypePosition in .definedAt (start, end):
+--
+--  - for fns/types position of the WHOLE body of defined value.
+--  - for fns defines line of value, the same for kind (line of its type
+--    definition)
+-- - for type ctors: start.column is a position of "=" or "|" symbol before it
+getTypeInfoWithUsages ::
+  Port ->
+  String ->
+  TypePosition ->
+  Maybe String ->
+  Modules.State ->
+  Aff (Maybe (TypeInfo /\ Array TypePosition))
+getTypeInfoWithUsages port word wordPos qualifier moduleState = do
+  -- Find where the target is defined.
+  typeInfos <-
+    (eitherToErr $ P.type' port word moduleFilters moduleState.main)
+  -- Find its usages. First, try to check if if the target is in the defined
+  -- positions. Then for each defined position find usages until they contain
+  -- the target.
+
+  case findInDefined typeInfos of
+    Just info ->
+      getUsages info <#> Just <<< (/\) info
+    Nothing ->
+      -- Find usage corresponding to target.
+      f >>= maybe findTy (pure <<< Just)
+      where
+      f = Array.foldM
+        (\res info -> maybe (getCheckedUsages info) (pure <<< Just) res)
+        Nothing
+        typeInfos
+      findTy = case findTypeInDefined typeInfos of
+        Just info -> getUsages info <#> Just <<< (/\) info
+        Nothing -> pure Nothing
+  where
+
+  checkPosition =
+    comparePositions wordPos
+
+  getCheckedUsages info = getUsages info
+    <#> \usages ->
+      (Array.find checkPosition usages) <#>
+        (const $ info /\ usages)
+
+  isMaybeTypeCtor = startsWithCapitalLetter word
+
+  comparePositionFile (TypePosition p1) (TypePosition p2) =
+    String.toLower p1.name == String.toLower p2.name
+
+  isTypeOrFnDecl (TypeInfo { declarationType }) =
+    case declarationType of
+      Just DeclValue -> true
+      Just DeclType -> true
+      Just DeclTypeSynonym -> true
+      Just DeclTypeClass -> true
+      _ -> false
+
+  -- typeInfo.definedAt points to: to value level definition (not a signature)
+  -- or Type definition (not a kind signature) or ADT ctor.
+  --
+  -- ADT ctor symbolic  name can be the same as Type name: in this case
+  -- PscIde.usages returns two typeInfos in the same file (Type first then Ctor
+  -- in the list).
+  findInDefined typeInfos =
+    Array.findMap
+      ( \ti@(TypeInfo { definedAt }) ->
+          definedAt
+            <#>
+              ( \tp ->
+                  -- Check if renaming ident position is inside defined.
+                  checkPositionNested wordPos tp
+              -- If target rename ident is an exported ref or type
+              -- signature name they are not in the source position that
+              -- comes in definedAt. So we just check if this is the same
+              -- module.
+              --|| (isTypeOrFnDecl ti && comparePositionFile wordPos tp)
+              )
+            >>= case _ of
+              true -> Just ti
+              false -> Nothing
+      )
+      -- Reverse order of found defs, because first we want to check ctor def
+      -- which comes after type def in the result.
+      (Array.reverse typeInfos)
+
+  findTypeInDefined typeInfos =
+    Array.findMap
+      ( \ti@(TypeInfo { definedAt }) ->
+          definedAt
+            <#>
+              ( \tp ->
+                  (isTypeOrFnDecl ti && comparePositionFile wordPos tp)
+              )
+            >>= case _ of
+              true -> Just ti
+              false -> Nothing
+      )
+      -- Reverse order of found defs, because first we want to check ctor def
+      -- which comes after type def in the result.
+      (Array.reverse typeInfos)
+
+  -- For not exported identifiers ide usages returns the error "Declaration not
+  -- found".
+  getUsages ti@(TypeInfo { module' }) =
+    -- Need to nub because currently (until fixed) purs ide may return
+    -- duplicated positions, in case if imports are duplicated.
+    Array.nubByEq comparePositions <$>
+      ( eitherToErr $ P.usages port module'
+          (typeInfoToNs ti)
+          word
+      )
+
+  unqualModules =
+    -- if it is possibly constructor then we search in every possible module
+    if isMaybeTypeCtor then
+      Modules.getAllUnqualActiveModules moduleState
+    else
+      getUnqualActiveModules moduleState (Just word)
+
+  getQualifiedModule = flip getQualModule moduleState
+
+  moduleFilters =
+    [ C.ModuleFilter $ maybe unqualModules getQualifiedModule qualifier ]
+
+type LocalUsage = { ranges :: Array Range }
+type ExternUsage = { typeInfo :: TypeInfo, usages :: Array (TypePosition) }
+
+type IdentInfo =
+  { word :: String
+  , found :: Either LocalUsage ExternUsage
+  , range :: Range
+  }
+
+-- | Finds information about definition and usages of rename target given
+-- original position and LSP stuff.
+getIdentInfo ::
+  DocumentStore ->
+  Settings ->
+  ServerState ->
+  TextDocumentPositionParams ->
+  Aff (Maybe IdentInfo)
+getIdentInfo docs _ state { textDocument, position } = do
+  let { port, modules } = un ServerState $ state
+  let uri = _.uri $ un TextDocumentIdentifier textDocument
+  mbDoc <- liftEffect $
+    Nullable.toMaybe <$> getDocument docs uri
+  mbDoc
+    # maybe (pure empty) \doc -> do
+        lineText <- liftEffect $ getTextAtRange doc (mkRange position)
+        case port, getIdentFromLine lineText of
+          Just port', Just { word, qualifier, range } -> do
+            modulePath <- liftEffect $ uriToFilename uri
+            infoUsage <-
+              getTypeInfoWithUsages port' word
+                ( mkTypePosition modulePath
+                    (mkWordRange position range Nothing)
+                )
+                qualifier
+                modules
+            pure case infoUsage of
+              Just (typeInfo /\ usages)
+                -- Forbid refactoring in libraries (for now).
+                | isLibType typeInfo -> Nothing
+                | otherwise ->
+                    -- Currently PscIde (purs ide) returns no usage for any type
+                    -- namespace. So for now in this case it is better to disable
+                    -- rename for type level if it returns empty usages.
+                    --
+                    -- We should remove this check when it is fixed.
+                    if isNSType (typeInfoToNs typeInfo) && Array.null usages then
+                      Nothing
+                    else
+                      Just
+                        { word
+                        , range: mkWordRange position range qualifier
+                        , found: Right { typeInfo, usages: usages }
+                        }
+              _ ->
+                empty
+          _, _ -> pure empty
+  where
+  empty = Nothing
+
+  isLibType (TypeInfo { definedAt: Just (TypePosition p) }) =
+    String.contains (String.Pattern ".spago") p.name
+  isLibType _ = false
+
+  getIdentFromLine lineText =
+    (identifierAtPoint lineText (_.character $ un Position position))
+
+  -- make line range with target identifier
+  mkRange pos =
+    Range
+      { start: pos # over Position (_ { character = 0 })
+      , end: pos # over Position
+          (\c -> c { character = c.character + maxIdentLen })
+      }
+    where
+    maxIdentLen = 100
+  mkWordRange pos { left, right } qualifier =
+    Range
+      { start: pos # over Position mkStart
+      , end: pos # over Position (\c -> c { character = right })
+      }
+    where
+    mkStart = _
+      { character = left +
+          -- adjust start if qualified
+          (maybe 0 (\s -> String.length s + 1) qualifier)
+      }
+
+  rangePosToTypePos (Position { character, line }) =
+    { column: character + 1, line: line + 1 } -- differs by 1
+
+  mkTypePosition filePath (Range { start, end }) =
+    TypePosition
+      { name: filePath
+      , start: rangePosToTypePos start
+      , end: rangePosToTypePos end
+      }
+
+splitLines :: String -> Array String
+splitLines =
+  String.split (Pattern "\n")
+
+eitherToErr :: forall a. Aff (Either String a) -> (Aff a)
+eitherToErr c = do
+  r <- c
+  case r of
+    Left s -> throwError (error s)
+    Right res -> pure res
+
+isNSType :: C.Namespace -> Boolean
+isNSType =
+  case _ of
+    NSType -> true
+    _ -> false
+
+typeInfoToNs :: TypeInfo -> C.Namespace
+typeInfoToNs (TypeInfo { declarationType }) =
+  maybe NSValue
+    case _ of
+      DeclValue -> NSValue
+      DeclType -> NSType
+      DeclTypeSynonym -> NSType
+      DeclDataConstructor -> NSValue
+      DeclTypeClass -> NSType
+      DeclValueOperator -> NSValue
+      DeclTypeOperator -> NSType
+      DeclModule -> NSType
+    declarationType
+
+-- Check if positions are  the same we compare only start position.
+comparePositions :: TypePosition -> TypePosition -> Boolean
+comparePositions (TypePosition pos1) (TypePosition pos2) =
+  comparePaths pos1.name pos2.name
+    && (pos1.start == pos2.start)
+  --&& (pos1.end == pos2.end)
+  where
+  -- Paths may differ on windows because of drive letter.
+  comparePaths p1 p2 =
+    String.toLower p1 == String.toLower p2
+
+-- Check if the first position is nested inside the second one.
+checkPositionNested :: TypePosition -> TypePosition -> Boolean
+checkPositionNested (TypePosition inner) (TypePosition outer) =
+  comparePaths inner.name outer.name
+    && toTup outer.start <= toTup inner.start
+    && toTup inner.end <= toTup outer.end
+  where
+  toTup ({ line, column }) = line /\ column
+  -- "normalize" paths that may differ on windows (drive letter case)
+  comparePaths p1 p2 =
+    String.toLower p1 == String.toLower p2
+
+findWordInRange :: Pattern -> String -> Range -> Maybe Range
+findWordInRange (Pattern word) text range =
+  Array.findMap
+    ( \(lineNum /\ lineText) ->
+        searchIndex lineText
+          <#> \startChar ->
+            let
+              (Range { start: Position p }) = range
+              line = p.line + lineNum
+              character = p.character + startChar
+            in
+              Range
+                { start: Position { line, character }
+                , end:
+                    Position
+                      { line
+                      , character: character + String.length word
+                      }
+                }
+    )
+    $ Array.mapWithIndex
+        (\idx s -> idx /\ s)
+        (String.split (Pattern "\n") text)
+  where
+  isOp = maybe false (not <<< flip Regex.test word) $ hush
+    $ Regex.regex ("[a-z]") Regex.ignoreCase
+  searchIndex line
+    -- For operators use just search in string, for identifiers - regexp to
+    -- match the whole word
+    | isOp = String.indexOf (Pattern word) line
+    | otherwise =
+        (hush $ Regex.regex ("\\b" <> word <> "\\b") Regex.noFlags) >>=
+          flip Regex.search line
+
+getTextAtRangeInLines :: Array String -> Range -> String
+getTextAtRangeInLines lines (Range { start: Position start, end: Position end }) =
+  String.joinWith "\n"
+    ( Array.slice start.line (end.line + 1) lines
+        # cutEnd
+        # cutStart
+    )
+  where
+  cutStart ln =
+    case Array.uncons ln of
+      Just { head, tail } -> Array.cons (String.drop start.character head) tail
+      _ -> ln
+  cutEnd ln =
+    case Array.unsnoc ln of
+      Just { init, last } -> Array.snoc init
+        (String.take (end.character) last)
+      _ -> ln

--- a/src/LanguageServer/IdePurescript/Rename/CST.purs
+++ b/src/LanguageServer/IdePurescript/Rename/CST.purs
@@ -1,0 +1,110 @@
+module LanguageServer.IdePurescript.Rename.CST where
+
+import Prelude
+
+import Data.Array as Array
+import Data.Maybe (Maybe(..), maybe)
+import Data.Newtype (unwrap)
+import Data.Tuple (snd)
+import Data.Tuple.Nested ((/\))
+import LanguageServer.IdePurescript.Util.CST (sourceRangeToRange)
+import LanguageServer.Protocol.Types (Range)
+import PureScript.CST.Types (DataMembers(..), Declaration(..), Delimited, DelimitedNonEmpty, Export(..), Ident(..), Import(..), ImportDecl(..), Labeled(..), Module(..), ModuleBody(..), ModuleHeader(..), ModuleName, Name(..), Operator(..), Proper(..), Separated(..), SourceRange, Wrapped(..))
+
+delimitedToArray :: forall a. Delimited a -> Array a
+delimitedToArray (Wrapped { value: Just (Separated { head, tail }) }) =
+  Array.cons head (snd <$> tail)
+delimitedToArray _ = []
+
+delimitedToArray' :: forall a. DelimitedNonEmpty a -> Array a
+delimitedToArray' (Wrapped { value: (Separated { head, tail }) }) =
+  Array.cons head (snd <$> tail)
+
+getExportedRanges :: forall a. Module a -> Boolean -> String -> Array Range
+getExportedRanges (Module { header: ModuleHeader { exports } }) isType name =
+  sourceRangeToRange
+    <$> Array.foldMap go (maybe [] delimitedToArray' exports)
+  where
+  go = case _ of
+    ExportValue (Name { token, name: Ident ident })
+      | ident == name -> pure token.range
+
+    ExportType (Name { token, name: Proper proper }) _
+      | isType && proper == name -> pure token.range
+
+    ExportType _ (Just (DataEnumerated ctors))
+      | not isType -> maybe [] pure (findCtor name ctors)
+
+    ExportOp (Name { token, name: Operator op })
+      | not isType && op == name -> pure token.range
+
+    ExportTypeOp _ (Name { token, name: Operator op })
+      | isType && op == name -> pure token.range
+
+    ExportClass _ (Name { token, name: Proper proper })
+      | isType && name == proper -> pure token.range
+
+    _ -> []
+
+shiftRange :: Int -> SourceRange -> SourceRange
+shiftRange num org@{ start, end } =
+  if num == 0 then
+    org
+  else
+    { start: { column: start.column + num, line: start.line }
+    , end: { column: end.column + num, line: end.line }
+    }
+
+findCtor :: String -> Delimited (Name Proper) -> Maybe SourceRange
+findCtor name ctors =
+  Array.findMap
+    ( \c ->
+        if unwrap c.name == name then Just c.token.range
+        else Nothing
+    )
+    (unwrap <$> delimitedToArray ctors)
+
+getImportedRanges :: forall a. Module a -> Boolean -> String -> ModuleName -> Array Range
+getImportedRanges (Module { header: ModuleHeader { imports } }) isType name moduleName =
+  sourceRangeToRange <$> Array.foldMap go imports
+  where
+  go (ImportDecl { names, module: (Name { name: mn }) })
+    | mn == moduleName = maybe [] goName names
+    | otherwise = []
+  goName (_ /\ delim) = Array.foldMap
+    case _ of
+      ImportValue (Name { token, name: Ident ident })
+        | not isType && ident == name -> pure token.range
+
+      ImportType (Name { token, name: Proper proper }) _
+        | isType && proper == name -> pure token.range
+
+      ImportType _ (Just (DataEnumerated ctors))
+        | not isType -> maybe [] pure (findCtor name ctors)
+
+      ImportOp (Name { token, name: Operator op })
+        | not isType && op == name -> pure token.range
+
+      ImportTypeOp _ (Name { token, name: Operator op })
+        | isType && op == name -> pure token.range
+
+      ImportClass _ (Name { token, name: Proper proper })
+        | isType && name == proper -> pure token.range
+
+      _ ->
+        []
+    (delimitedToArray' delim)
+
+getDeclSignatureName :: forall a. Module a -> Boolean -> String -> Maybe Range
+getDeclSignatureName (Module { body: ModuleBody { decls } }) isType name =
+  sourceRangeToRange
+    <$> Array.findMap
+      case _ of
+        DeclSignature (Labeled { label: Name { token, name: Ident ident } })
+          | (ident == name) -> Just token.range
+
+        DeclKindSignature _ (Labeled ({ label: Name { token, name: Proper proper } }))
+          | (isType && proper == name) -> Just token.range
+        _ ->
+          Nothing
+      decls

--- a/src/LanguageServer/IdePurescript/Types.purs
+++ b/src/LanguageServer/IdePurescript/Types.purs
@@ -16,10 +16,11 @@ import Effect.Aff (Aff, Fiber)
 import Effect.Timer (TimeoutId)
 import Foreign (Foreign)
 import IdePurescript.Modules (State) as Modules
+import IdePurescript.PscIdeServer (Port)
 import LanguageServer.Protocol.TextDocument (TextDocument)
 import LanguageServer.Protocol.Types (ClientCapabilities, Connection, Diagnostic, DocumentStore, DocumentUri, Settings)
 import PscIde.Command (RebuildError)
-import PscIde.Server (Executable(..))
+import PscIde.Server (Executable)
 import PureScript.CST (RecoveredParserResult)
 import PureScript.CST.Types (Module)
 
@@ -36,18 +37,18 @@ data RebuildRunning
   | FastRebuild (Map DocumentUri TextDocument)
   | DiagnosticsRebuild (Map DocumentUri TextDocument)
 
-type ServerStateRec 
-  = { -- purs ide state 
-      -- TODO merge this into one Maybe
-      port :: Maybe Int
+type ServerStateRec =
+  { -- Purs ide state.
+    -- TODO merge this into one Maybe
+    port :: Maybe Port
   , root :: Maybe String
-    , deactivate :: Aff Unit
-    , purs :: Maybe Executable
-    -- LSP state
+  , deactivate :: Aff Unit
+  , purs :: Maybe Executable
+  -- LSP state.
   , conn :: Maybe Connection
   , clientCapabilities :: Maybe ClientCapabilities
   --
-  , runningRebuild ::      Maybe { fiber :: Fiber Unit, uri :: DocumentUri, version :: Number }
+  , runningRebuild :: Maybe { fiber :: Fiber Unit, uri :: DocumentUri, version :: Number }
   --
   , rebuildRunning :: Maybe RebuildRunning
   , fastRebuildQueue :: Map DocumentUri TextDocument
@@ -57,7 +58,11 @@ type ServerStateRec
   , savedCacheDb :: Maybe CacheDb
   , revertCacheDbTimeout :: Maybe TimeoutId
   --
-    -- state updated on document change
+  -- State updated on document change.
+
+  -- `modules` store "currently active in the editor" module state (imports and
+  -- used identifiers). It is updated on any handled event related to to active
+  -- document in the editor.
   , modules :: Modules.State
   , modulesFile :: Maybe DocumentUri
   , diagnostics :: DiagnosticState

--- a/src/LanguageServer/Protocol/Handlers.js
+++ b/src/LanguageServer/Protocol/Handlers.js
@@ -55,6 +55,12 @@ export var onFoldingRanges = function (conn) {
 export var onDocumentFormatting = function (conn) {
     return registerHandler(conn.onDocumentFormatting);
 };
+export var onPrepareRename = function (conn) {
+    return registerHandler(conn.onPrepareRename);
+};
+export var onRenameRequest = function (conn) {
+    return registerHandler(conn.onRenameRequest);
+};
 export var onDidChangeConfiguration = function (conn) {
     return registerNotificationHandler(conn.onDidChangeConfiguration);
 };

--- a/src/LanguageServer/Protocol/Handlers.purs
+++ b/src/LanguageServer/Protocol/Handlers.purs
@@ -38,7 +38,20 @@ type CodeLensResult =
 
 type FoldingRangesParams = { textDocument :: TextDocumentIdentifier }
 
-type DocumentFormattingParams = { textDocument :: TextDocumentIdentifier }
+type DocumentFormattingParams =
+  { textDocument :: TextDocumentIdentifier
+  }
+
+type PrepareRenameParams =
+  { textDocument :: TextDocumentIdentifier
+  , position :: Position
+  }
+
+type RenameParams =
+  { textDocument :: TextDocumentIdentifier
+  , position :: Position
+  , newName :: String
+  }
 
 type DidChangeConfigurationParams = { settings :: Foreign }
 
@@ -94,6 +107,12 @@ foreign import onDocumentFormatting ::
   Connection ->
   (DocumentFormattingParams -> Res (Array TextEdit)) ->
   Effect Unit
+
+foreign import onPrepareRename ::
+  Connection -> (PrepareRenameParams -> Res (Nullable Range)) -> Effect Unit
+
+foreign import onRenameRequest ::
+  Connection -> (RenameParams -> Res WorkspaceEdit) -> Effect Unit
 
 foreign import onDidChangeConfiguration ::
   Connection -> (DidChangeConfigurationParams -> Effect Unit) -> Effect Unit

--- a/src/LanguageServer/Protocol/Handlers.ts
+++ b/src/LanguageServer/Protocol/Handlers.ts
@@ -6,7 +6,7 @@ import {
   PublishDiagnosticsParams,
   WorkspaceEdit,
   Connection,
-} from "vscode-languageserver/node";
+} from "vscode-languageserver/node.js";
 import { NotificationType0 } from "vscode-jsonrpc";
 
 let registerHandler =
@@ -61,6 +61,12 @@ export const onFoldingRanges = (conn: Connection) =>
 
 export const onDocumentFormatting = (conn: Connection) =>
   registerHandler(conn.onDocumentFormatting);
+
+export const onPrepareRename = (conn: Connection) =>
+  registerHandler(conn.onPrepareRename);
+
+export const onRenameRequest = (conn: Connection) =>
+  registerHandler(conn.onRenameRequest);
 
 export const onDidChangeConfiguration = (conn: Connection) =>
   registerNotificationHandler(conn.onDidChangeConfiguration);

--- a/src/LanguageServer/Protocol/Setup.js
+++ b/src/LanguageServer/Protocol/Setup.js
@@ -1,4 +1,4 @@
-import { createConnection, TextDocuments, CodeActionKind, TextDocumentSyncKind, } from "vscode-languageserver/node";
+import { createConnection, TextDocuments, CodeActionKind, TextDocumentSyncKind, } from "vscode-languageserver/node.js";
 import { TextDocument } from "vscode-languageserver-textdocument";
 export var initConnection = function (commands) {
     return function (cb) {
@@ -39,6 +39,10 @@ export var initConnection = function (commands) {
                                 CodeActionKind.SourceFixAll,
                                 CodeActionKind.Source,
                             ],
+                        },
+                        renameProvider: {
+                            prepareProvider: true,
+                            workDoneProgress: true
                         },
                         executeCommandProvider: (params.initializationOptions || {})
                             .executeCommandProvider === false

--- a/src/LanguageServer/Protocol/Setup.ts
+++ b/src/LanguageServer/Protocol/Setup.ts
@@ -6,7 +6,7 @@ import {
   CodeActionKind,
   LSPObject,
   TextDocumentSyncKind,
-} from "vscode-languageserver/node";
+} from "vscode-languageserver/node.js";
 import { TextDocument } from "vscode-languageserver-textdocument";
 
 export const initConnection =
@@ -51,6 +51,10 @@ export const initConnection =
               CodeActionKind.SourceFixAll,
               CodeActionKind.Source,
             ],
+          },
+          renameProvider: {
+            prepareProvider: true,
+            workDoneProgress: true
           },
           executeCommandProvider:
             ((params.initializationOptions as LSPObject) || {})

--- a/src/LanguageServer/Protocol/Types.purs
+++ b/src/LanguageServer/Protocol/Types.purs
@@ -41,6 +41,7 @@ instance showDocumentUri :: Show DocumentUri where
 derive newtype instance eqDocumentUri :: Eq DocumentUri
 derive newtype instance Ord DocumentUri
 
+-- Line and character indexes, start from 0
 newtype Position = Position { line :: Int, character :: Int }
 
 instance eqPosition :: Eq Position where

--- a/src/LanguageServer/Protocol/Window.ts
+++ b/src/LanguageServer/Protocol/Window.ts
@@ -2,7 +2,7 @@ import {
   Connection,
   MessageActionItem,
   WorkDoneProgressServerReporter,
-} from "vscode-languageserver/node";
+} from "vscode-languageserver/node.js";
 
 export const showError = (conn: Connection) => (s: string) => () =>
   conn.window.showErrorMessage(s);

--- a/src/LanguageServer/Protocol/Workspace.js
+++ b/src/LanguageServer/Protocol/Workspace.js
@@ -1,4 +1,4 @@
-import { CodeLensRefreshRequest, } from "vscode-languageserver/node";
+import { CodeLensRefreshRequest, } from "vscode-languageserver/node.js";
 export var codeLensRefresh = function (conn) { return function () {
     return conn.sendRequest(CodeLensRefreshRequest.type);
 }; };

--- a/src/LanguageServer/Protocol/Workspace.ts
+++ b/src/LanguageServer/Protocol/Workspace.ts
@@ -2,7 +2,7 @@ import {
   CodeLensRefreshRequest,
   Connection,
   MessageActionItem,
-} from "vscode-languageserver/node";
+} from "vscode-languageserver/node.js";
 
 export const codeLensRefresh = (conn: Connection) => () =>
   conn.sendRequest(CodeLensRefreshRequest.type);

--- a/test/Fixture/RenameA.purs
+++ b/test/Fixture/RenameA.purs
@@ -1,0 +1,37 @@
+module Test.Fixture.RenameA
+  ( func1
+  , DataType(ACons, BCons)
+  , Newt(Newt)
+  , TypeSyn
+  , class ClsA
+  , toInt
+  , Tup(..)
+  , (/\)
+  , type (/\)
+  ) where
+
+type TypeSyn :: Type
+type TypeSyn = Int
+
+data DataType :: Type
+data DataType = ACons Int | BCons
+
+newtype Newt :: Type
+newtype Newt = Newt Int
+
+func1 :: Int -> TypeSyn
+func1 int =
+  int
+
+newT = Newt 10
+
+local1 :: Int
+local1 = func1 10
+
+class ClsA a where
+  toInt :: a -> Int
+
+data Tup a b = Tup a b
+
+infixl 5 type Tup as /\
+infixl 5 Tup as /\

--- a/test/Fixture/RenameB.purs
+++ b/test/Fixture/RenameB.purs
@@ -1,0 +1,26 @@
+module Test.Fixture.RenameB where
+
+import Test.Fixture.RenameA (class ClsA, DataType(ACons), Newt(Newt), TypeSyn, func1, toInt, Tup(..), (/\), type (/\))
+import Test.Fixture.RenameA as A
+
+dt :: A.DataType
+dt = A.ACons 0
+
+dt2 :: DataType
+dt2 = ACons 0
+
+val1 = A.func1 0
+
+data TypeB = TypeB TypeSyn
+
+instance ClsA TypeB where
+  toInt (TypeB v) = func1 v
+
+fnCls :: forall a. ClsA a => a -> TypeSyn
+fnCls = toInt
+
+newT :: Newt
+newT = Newt 1
+
+tup :: Int /\ String
+tup = 1 /\ "1"

--- a/test/Fixture/RenameB.purs
+++ b/test/Fixture/RenameB.purs
@@ -1,6 +1,6 @@
 module Test.Fixture.RenameB where
 
-import Test.Fixture.RenameA (class ClsA, DataType(ACons), Newt(Newt), TypeSyn, func1, toInt, Tup(..), (/\), type (/\))
+import Test.Fixture.RenameA (class ClsA, DataType(ACons), Newt(Newt), TypeSyn, func1, func1, toInt, Tup(..), (/\), type (/\))
 import Test.Fixture.RenameA as A
 
 dt :: A.DataType

--- a/test/Rename.purs
+++ b/test/Rename.purs
@@ -1,0 +1,531 @@
+module Test.Rename (main) where
+
+import Prelude
+
+import Control.Apply (lift2)
+import Data.Array as Array
+import Data.Either (Either(..), note)
+import Data.Map (Map)
+import Data.Map as Map
+import Data.Maybe (Maybe(..), fromMaybe, maybe)
+import Data.Newtype (class Newtype, over, unwrap)
+import Data.String (Pattern(..), Replacement(..))
+import Data.String as String
+import Data.Traversable (traverse)
+import Data.Tuple.Nested (type (/\), (/\))
+import Effect (Effect)
+import Effect.Aff (Aff, launchAff_)
+import Effect.Class (liftEffect)
+import Effect.Exception (throw)
+import Foreign (unsafeToForeign)
+import IdePurescript.Modules as Modules
+import IdePurescript.PscIdeServer (Notify, Port)
+import IdePurescript.Tokens (identifierAtPoint)
+import LanguageServer.IdePurescript.Rename as R
+import LanguageServer.IdePurescript.Server as PursIde
+import LanguageServer.Protocol.Types (Position(..), Range(..))
+import LanguageServer.Protocol.Uri (filenameToUri)
+import Node.Encoding (Encoding(..))
+import Node.FS.Aff as FS
+import Node.Process as Process
+import PscIde as PscIde
+import PscIde.Command (TypePosition(..))
+import PureScript.CST (parseModule)
+import Test.Spec (it)
+import Test.Spec as S
+import Test.Spec.Assertions as A
+import Test.Spec.Reporter (consoleReporter)
+import Test.Spec.Runner (runSpec)
+
+emptyNotify :: Notify
+emptyNotify _ _ =
+  pure unit
+
+newtype ModuleName = ModuleName String
+newtype ModulePath = ModulePath String
+newtype ModuleText = ModuleText String
+
+derive instance Newtype ModuleName _
+derive instance Eq ModuleName
+derive instance Ord ModuleName
+
+derive instance Newtype ModulePath _
+derive instance Newtype ModuleText _
+
+newtype LinePattern = LinePattern String
+newtype IdentPattern = IdentPattern String
+
+newtype Ident = Ident String
+newtype LineIdx = LineIdx Int
+
+{-
+Text position types involved in tests:
+
+LS.Protocol.Types:
+  starts from 0
+  Position = Position { line :: Int, character :: Int }
+  Range = Range { start :: Position, end :: Position }
+
+PscIde:
+  Position = { line :: Int, column :: Int } -- starts from 1
+  TypePosition =
+    TypePosition { name :: String, start :: Position, end :: Position }
+                  ^ name is module file path
+
+IdePurescript.Tokens:
+  WordRange = { left :: Int, right :: Int }
+-}
+
+getTypePos ::
+  ModulePath -> ModuleText -> LinePattern -> Pattern -> Maybe TypePosition
+getTypePos modulePath (ModuleText text) (LinePattern linePtn) identPtn = do
+  line <- Array.findIndex (String.contains (Pattern linePtn)) lines
+  lineText <- Array.index lines line
+  character <-
+    -- First search inside the line pattern then in the line text.
+    case String.indexOf identPtn linePtn, String.indexOf (Pattern linePtn) lineText of
+      Just idx, Just linePtnIdx -> Just $ idx + linePtnIdx
+      _, _ -> String.indexOf identPtn lineText
+  pure $ TypePosition
+    { name: unwrap modulePath
+    , start: { column: character + 1, line: line + 1 }
+    -- The end column position is a position of the last character.
+    , end: { column: character + identLen + 1, line: line + 1 }
+    }
+  where
+  lines = String.split (Pattern "\n") text
+  identLen = String.length $ unwrap identPtn
+
+getIdentTypePos ::
+  ModulePath ->
+  ModuleText ->
+  LinePattern ->
+  IdentPattern ->
+  Maybe { typePos :: TypePosition, ident :: Ident, qualifier :: Maybe String }
+getIdentTypePos
+  (ModulePath modulePath)
+  (ModuleText text)
+  (LinePattern linePtn)
+  (IdentPattern ident) = do
+
+  lineIdx <- Array.findIndex (String.contains (Pattern linePtn)) lines
+  lineText <- Array.index lines lineIdx
+  linePtnIdx <- String.indexOf (Pattern linePtn) lineText
+  -- First search inside the line pattern then in the line text.
+  character <- case String.indexOf (Pattern ident) linePtn of
+    Just idx -> Just (linePtnIdx + idx)
+    _ -> String.indexOf (Pattern ident) lineText
+
+  let position = Position { character, line: lineIdx }
+  { word, qualifier, range } <-
+    identifierAtPoint lineText character
+  pure
+    { typePos: mkTypePosition modulePath $ mkWordRange position range Nothing
+    , ident: Ident word
+    , qualifier: qualifier
+    }
+  where
+  lines = String.split (Pattern "\n") text
+
+  posToTypePos (Position { character, line }) =
+    { column: character + 1, line: line + 1 } -- Differs by 1.
+  mkWordRange pos { left, right } qualifier =
+    Range
+      { start: pos # over Position mkStart
+      , end: pos # over Position (\c -> c { character = right })
+      }
+    where
+    mkStart = _
+      { character = left
+          -- Adjust start if qualified.
+          + (maybe 0 (\s -> String.length s + 1) qualifier)
+      }
+  mkTypePosition filePath (Range { start, end }) =
+    TypePosition
+      { name: filePath
+      , start: posToTypePos start
+      , end: posToTypePos end
+      }
+
+rangeFromTp :: TypePosition -> Range
+rangeFromTp (TypePosition { start, end }) =
+  (Range { start: toR start, end: toR end })
+  where
+  toR { column, line } = Position
+    { character: column - 1
+    , line: line - 1
+    }
+
+splitLines :: String -> Array String
+splitLines =
+  String.split (Pattern "\n")
+
+fileToModuleName :: String -> String
+fileToModuleName filePath = fromMaybe filePath do
+  name <- Array.last $ String.split (Pattern "test/") filePath
+  pure $ name
+    # String.replace (Pattern ".purs") (Replacement "")
+    # String.replaceAll (Pattern ("/")) (Replacement ".")
+    # String.replaceAll (Pattern ("\"")) (Replacement "")
+
+renderRange :: Range -> String
+renderRange (Range { start, end }) =
+  renderPos start <> "-" <> renderPos end
+  where
+  renderPos (Position { character, line }) =
+    show (line + 1) <> ":" <> show (character + 1)
+
+editsToCompare :: R.TextEditsMap -> Array (String /\ Array (String /\ String))
+editsToCompare edits =
+  Map.toUnfoldable edits <#>
+    \((uri /\ _) /\ ranges) ->
+      (fileToModuleName $ show uri)
+        --/\ (Array.sort $ ranges <#> renderRange <<< _.range)
+        /\ (Array.sort $ ranges <#> map renderRange <<< lift2 (/\) _.newText _.range)
+
+-- | Coverts found type position to ["Module.Name" /\ ["1:10-1:15"]]
+tpsToCompare ::
+  Array (String /\ TypePosition) -> Array (String /\ Array (String /\ String))
+tpsToCompare positions =
+  Map.toUnfoldable $ gather
+    $ positions <#> \(searchText /\ tp@(TypePosition { name })) ->
+        fileToModuleName name /\ (searchText /\ (renderRange $ rangeFromTp tp))
+  where
+  addRange range = pure <<< maybe [ range ] (Array.sort <<< flip (<>) [ range ])
+  gather = Array.foldl
+    (\m (key /\ range) -> Map.alter (addRange range) key m)
+    Map.empty
+
+type ModulePrep =
+  { state :: Modules.State
+  , name :: ModuleName
+  , path :: ModulePath
+  , text :: ModuleText
+  }
+
+type PrepareResult =
+  { port :: Port
+  , modules :: Map ModuleName ModulePrep
+  , docsToEdit :: Map String R.DocToEdit
+  }
+
+-- | Prepare tests. Starts purs ide server, rebuilds test modules.
+prepare :: Aff PrepareResult
+prepare = do
+  cwdDir <- liftEffect $ Process.cwd
+  let rootPath = cwdDir <> "/test"
+
+  let settings = unsafeToForeign {}
+  startRes <- PursIde.startServer' settings rootPath notify notify
+
+  case startRes of
+    { port: Just port } -> do
+      rebuild moduleA
+      rebuild moduleB
+
+      modules <- prepareModules
+      docsToEdit <- getDocsToEdit
+
+      pure { port, modules, docsToEdit }
+
+      where
+      moduleA = ModuleName "Test.Fixture.RenameA"
+      moduleB = ModuleName "Test.Fixture.RenameB"
+
+      allModules = [ moduleA, moduleB ]
+
+      prepareModules = Map.fromFoldable <$>
+        traverse
+          ( \mn -> do
+              prepared <- prepareModule mn
+              pure $ mn /\ prepared
+          )
+          allModules
+
+      prepareModule mName = do
+        text <- readModuleText mName
+        state <- getModuleState mName text
+        pure { text, state, name: mName, path: toPath mName }
+
+      getDocsToEdit = Map.fromFoldable <$>
+        traverse
+          ( \path -> do
+              uri <- liftEffect $ filenameToUri path
+              docText <- FS.readTextFile (UTF8) path
+              let docLines = splitLines docText
+              pure $ path /\
+                { uri
+                , docTextAtRange:
+                    \range ->
+                      R.getTextAtRangeInLines docLines range
+                , version: Nothing
+                , parsed: parseModule docText
+                }
+          )
+          (toPathStr <$> allModules)
+
+      readModuleText moduleN =
+        ModuleText <$> FS.readTextFile UTF8 (unwrap $ toPath moduleN)
+
+      getModuleState moduleN (ModuleText moduleText) =
+        Modules.getModulesForFileTemp port mPath moduleText
+        where
+        (ModulePath mPath) = toPath moduleN
+
+      rebuild moduleN = do
+        buildRes <-
+          PscIde.rebuild port mPath (Just mPath) Nothing
+        --(Just targets)
+        case buildRes of
+          Left err ->
+            --log $ "Rebuild error: " <> err
+            A.fail $ "Module rebuild error: " <> err
+          Right _ ->
+            --log "Rebuild ok"
+            pure unit
+        where
+        (ModulePath mPath) = toPath moduleN
+
+      toPathStr = unwrap <<< toPath
+
+      toPath (ModuleName m) =
+        ModulePath $
+          rootPath <> "/" <>
+            (String.replaceAll (Pattern ".") (Replacement "/") m)
+            # String.replace (Pattern "Test/") (Replacement "")
+            # flip (<>) ".purs"
+
+    _ ->
+      liftEffect $ throw "Could not start ide server"
+  where
+  notify = emptyNotify
+
+-- | Test Rename.getTextEdits function.
+--mySpec :: SpecT Aff Unit Effect Unit
+renameSpec :: PrepareResult -> S.Spec Unit
+renameSpec prep = do
+  S.before (pure prep) $
+    --S.beforeAll prepare $
+    S.describe "Find usages for rename refactor" do
+
+      let
+        expectedFunc =
+          [ moduleA /\ "func1 ::" /\ "func1" -- def
+          , moduleA /\ "func1 int" /\ "func1"
+          , moduleA /\ "( func1" /\ "func1" -- export
+          , moduleA /\ "= func1 10" /\ "func1"
+          , moduleB /\ "import" /\ "func1"
+          , moduleB /\ "= A.func1 0" /\ "func1"
+          , moduleB /\ "func1 v" /\ "func1" -- inside instance
+          ]
+
+      testRename it "value ident - in def"
+        (moduleA /\ "func1 int" /\ "func1")
+        expectedFunc
+
+      testRename it "value ident - in signature"
+        (moduleA /\ "func1 :" /\ "func1")
+        expectedFunc
+
+      testRename it "value ident - in usage"
+        (moduleA /\ "func1 10" /\ "func1")
+        expectedFunc
+
+      let
+        expectedTypeSyn =
+          [ moduleA /\ "type TypeSyn =" /\ "TypeSyn" -- def
+          , moduleA /\ "type TypeSyn ::" /\ "TypeSyn" -- kind def
+          , moduleA /\ ", TypeSyn" /\ "TypeSyn" --export
+          , moduleA /\ "func1 ::" /\ "TypeSyn"
+          , moduleB /\ "import" /\ "TypeSyn"
+          , moduleB /\ "TypeB TypeSyn" /\ "TypeSyn"
+          , moduleB /\ "a -> TypeSyn" /\ "TypeSyn"
+          ]
+
+      testRename it "type synonym - in type def"
+        (moduleA /\ "type TypeSyn =" /\ "TypeSyn")
+        expectedTypeSyn
+
+      testRename it "type synonym - in kind signature"
+        (moduleA /\ "type TypeSyn :" /\ "TypeSyn")
+        expectedTypeSyn
+
+      testRename it "type synonym - in usage"
+        (moduleA /\ "Int -> TypeSyn" /\ "TypeSyn")
+        expectedTypeSyn
+
+      testRename it "type synonym - in type def"
+        (moduleA /\ "type TypeSyn =" /\ "TypeSyn")
+        expectedTypeSyn
+
+      testRename it "data type"
+        (moduleA /\ "data DataType :" /\ "DataType")
+        [ moduleA /\ "data DataType :" /\ "DataType" -- def kind
+        , moduleA /\ "data DataType =" /\ "DataType" -- def
+        , moduleA /\ "DataType(" /\ "DataType" -- export
+        , moduleB /\ "import" /\ "DataType"
+        , moduleB /\ "dt :: A.DataType" /\ "DataType"
+        , moduleB /\ "dt2 :: DataType" /\ "DataType"
+        ]
+
+      testRename it "data constructor"
+        (moduleB /\ "= ACons 0" /\ "ACons")
+        [ moduleA /\ "= ACons Int" /\ "ACons" -- def
+        , moduleA /\ "DataType(ACons" /\ "ACons" -- export
+        , moduleB /\ "import" /\ "ACons"
+        , moduleB /\ "dt = A.ACons 0" /\ "ACons"
+        , moduleB /\ "dt2 = ACons 0" /\ "ACons"
+        ]
+
+      let
+        expectedNewt =
+          [ moduleA /\ "newtype Newt ::" /\ "Newt" -- def kind
+          , moduleA /\ "newtype Newt =" /\ "Newt" -- def
+          , moduleA /\ "Newt(Newt" /\ "Newt" -- export
+          , moduleB /\ "Newt(Newt" /\ "Newt" --import
+          , moduleB /\ "newT ::" /\ "Newt"
+          ]
+
+      testRename it "newtype type - in def"
+        (moduleA /\ "newtype Newt =" /\ "Newt")
+        expectedNewt
+
+      testRename it "newtype type - in kind signature"
+        (moduleA /\ "newtype Newt :" /\ "Newt")
+        expectedNewt
+
+      testRename it "newtype type - in usage"
+        (moduleB /\ "newT :" /\ "Newt")
+        expectedNewt
+
+      let
+        expectedConsNewt =
+          [ moduleA /\ "= Newt Int" /\ "Newt" -- def
+          , moduleA /\ "Newt 10" /\ "Newt"
+          , moduleA /\ "ewt(Newt" /\ "Newt" -- export
+          , moduleB /\ "ewt(Newt" /\ "Newt" -- import
+          , moduleB /\ "newT =" /\ "Newt" -- import
+          ]
+
+      testRename it "newtype constructor - in def"
+        (moduleA /\ "= Newt Int" /\ "Newt")
+        expectedConsNewt
+
+      testRename it "newtype constructor - in usage"
+        (moduleA /\ "= Newt 10" /\ "Newt")
+        expectedConsNewt
+
+      let
+        expectedTc =
+          [ moduleA /\ "class ClsA a" /\ "ClsA" --def
+          , moduleA /\ ", class ClsA" /\ "ClsA" -- export
+          , moduleB /\ "class ClsA" /\ "ClsA" -- import
+          , moduleB /\ "instance ClsA" /\ "ClsA"
+          , moduleB /\ "ClsA a =>" /\ "ClsA"
+          ]
+
+      testRename it "type class - in def"
+        (moduleA /\ "class ClsA" /\ "ClsA")
+        expectedTc
+
+      testRename it "type class - in usage"
+        (moduleB /\ "ClsA a =>" /\ "ClsA")
+        expectedTc
+
+      -- Note: renaming of members in type class instances is not implemented,
+      -- as we can not get their locations from purs ide (because to declare
+      -- instances one doesn't need to import them explicitly, it would need
+      -- ad-hoc logic for this case).
+      --
+      -- But it would rename usages in expressions. And manual renaming in
+      -- instances will be required.
+      --
+      -- In future it is possible to implement it on LSP side using CST parsing:
+      -- will need to find usages of the type class, filter its usages in
+      -- instances, then find target member declarations in instances.
+      testRename it "type class member"
+        (moduleA /\ "toInt ::" /\ "toInt")
+        [ moduleA /\ "toInt ::" /\ "toInt" --def
+        , moduleA /\ ", toInt" /\ "toInt" -- export
+        , moduleB /\ "import" /\ "toInt" -- import
+        , moduleB /\ "= toInt" /\ "toInt" -- usage
+        -- finding instance member declaration - doesn't work
+        -- , moduleB /\ "toInt (TypeB v)" /\ "toInt"
+        ]
+
+      -- TODO: tests for value fixity, type fixity (value/ctor), value op, type op, kind
+
+      testRename it "value operator"
+        (moduleA /\ "5 Tup as" /\ "/\\")
+        [ moduleA /\ "5 Tup as" /\ "/\\" --def
+        , moduleA /\ ", (/\\)" /\ "/\\" -- export
+        , moduleB /\ "import" /\ "/\\" -- import
+        , moduleB /\ "tup =" /\ "/\\" -- usage
+        ]
+
+      testRename it "type operator"
+        (moduleA /\ "5 type Tup as" /\ "/\\")
+        [ moduleA /\ "5 type Tup as" /\ "/\\" --def
+        , moduleA /\ ", type (/\\)" /\ "/\\" -- export
+        , moduleB /\ "type (/\\)" /\ "/\\" -- import
+        , moduleB /\ "tup ::" /\ "/\\" -- usage
+        ]
+
+  -- TODO: multiple times export/imports
+
+  -- TODO: support renaming names in imports/exports
+
+  -- TODO: there is case when ident exists in import but not used in the code
+  -- (when purs ide provides imports)
+
+  where
+  moduleA = ModuleName "Test.Fixture.RenameA"
+  moduleB = ModuleName "Test.Fixture.RenameB"
+  testRename fn title (mn /\ linePtn /\ identPtn) expected =
+    fn testName \{ port, modules, docsToEdit } ->
+      let
+        res = do
+          module_ <- Map.lookup mn modules
+          pos <- getIdentTypePos module_.path module_.text
+            (LinePattern linePtn)
+            (IdentPattern identPtn)
+          pure $ module_ /\ pos
+      in
+        case res of
+          Just (modA /\ { typePos, ident: (Ident ident), qualifier }) -> do
+            mbUsage <-
+              R.getTypeInfoWithUsages port ident typePos qualifier modA.state
+            case mbUsage of
+              -- Returns usages: array of type positions.
+              Just (typeInfo /\ usages) -> do
+                let edits =
+                      R.getTextEdits typeInfo usages docsToEdit (newName ident) identPtn
+
+                case makeTps modules ident of
+                  Right tps ->
+                    editsToCompare edits `A.shouldEqual` tpsToCompare tps
+
+                  Left ((ModuleName mn') /\ lPtn /\ iPtn) ->
+                    A.fail $ "Could not find expected usage " <> show (mn' /\ lPtn /\ iPtn)
+              _ ->
+                A.fail "No usages found"
+            pure unit
+
+          _ ->
+            A.fail $ "Could not find identifier " <> identPtn
+    where
+    testName = ("Finds replacements for " <> title <> " (" <> identPtn <> ")")
+    newName ident = ident <> "X"
+
+    makeTps modules ident = flip traverse expected
+      \input@(mn' /\ lPtn /\ iPtn) -> note input do
+        { text, path } <- Map.lookup mn' modules
+        (/\) (replaceNewName ident iPtn)
+          <$> (getTypePos path text (LinePattern lPtn) (Pattern ident))
+
+    replaceNewName ident iPtn =
+      (String.replace (Pattern ident) (Replacement (newName ident)) iPtn)
+
+main :: Effect Unit
+main = launchAff_ do
+  prepare >>= runSpec [ consoleReporter ] <<< renameSpec


### PR DESCRIPTION
This PR adds rename refactoring capabilities to LS. It's supposed to support renaming of all kinds of exported identifiers (potentially even type classes with members 🤪), though due to the purs ide usage API issues it is limited when used with the current compiler version. Anyway it is still capable of renaming value/function identifiers and type constructors, though types and operators can not be renamed. 

I actually have ready updates for the compiler to fix those issues with the usage API.

Tests are in test\Rename.purs - all tests pass only with the updated compiler version with usages api fixed.

This doesn't currently support renaming of local/private identifiers. 

This PR is based on #194 (tidy formatting PR). All the changes referred to refactoring are in the single latest commit (yet).